### PR TITLE
Feature/import and export flag

### DIFF
--- a/browser/flagr-ui/src/components/FlagHistory.vue
+++ b/browser/flagr-ui/src/components/FlagHistory.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <el-card v-for="diff in diffs" :key="diff.timestamp" class="snapshot-container">
+    <el-card v-for="diff in diffs" :key="diff.newId" class="snapshot-container">
       <div slot="header" class="el-card-header">
         <el-row>
           <el-col :span="14">

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -30,7 +30,10 @@
           </el-row>
 
           <el-row>
-            <import-export-flags :flags="this.flags" class="import-export-flags"></import-export-flags>
+            <import-export-flags
+              :flags="this.flags"
+              class="import-export-flags"
+            ></import-export-flags>
           </el-row>
 
           <el-table

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -32,6 +32,7 @@
           <el-row>
             <import-export-flags
               :flags="this.flags"
+              :loadFlags="this.loadFlags"
               class="import-export-flags"
             ></import-export-flags>
           </el-row>
@@ -121,15 +122,18 @@ export default {
     }
   },
   created () {
-    Axios.get(`${API_URL}/flags`)
-      .then(response => {
-        let flags = response.data
-        this.loaded = true
-        flags.reverse()
-        this.flags = flags
-      }, handleErr.bind(this))
+    this.loadFlags()
   },
   methods: {
+    loadFlags () {
+      Axios.get(`${API_URL}/flags`)
+        .then(response => {
+          let flags = response.data
+          this.loaded = true
+          flags.reverse()
+          this.flags = flags
+      }, handleErr.bind(this))
+    },
     flagEnabledFormatter (row, col, val) {
       return val ? 'on' : 'off'
     },

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -30,16 +30,28 @@
           </el-row>
 
           <el-row>
-            <el-col>
-              <el-button
-                type="primary"
-                icon="el-icon-caret-bottom"
-                v-on:click="exportFlags"
-              >
-                Export all flags
-              </el-button>
-              <a ref="exportFile"/>
-            </el-col>
+            <el-button
+              type="primary"
+              icon="el-icon-caret-bottom"
+              v-on:click="exportFlags"
+            >
+              Export all flags
+            </el-button>
+            <a ref="exportFile"/>
+
+            <el-button
+              class="import-btn"
+              icon="el-icon-upload2"
+              @click="importFlags"
+            >
+              Import flags
+            </el-button>
+            <input
+              type="file"
+              hidden
+              id="importFlags"
+              @change="importFlagsChanged"
+            />
           </el-row>
 
           <el-table
@@ -179,6 +191,38 @@ export default {
       );
       exportFileHref.setAttribute("download", 'flags.json');
       exportFileHref.click();
+    },
+    onFileReaderLoaded (loadedFile) {
+      const fileContent = loadedFile.target.result;
+
+      try {
+        const flags = JSON.parse(fileContent);
+        debugger
+      }
+      catch (err) {
+        console.error('Failed to load flags from file', err)
+      }
+    },
+    importFlags (e) {
+      e.preventDefault()
+      if (!window.FileReader) {
+        console.info('Reading files is not supported for that browser. Please try using anthor one.')
+        return;
+      }
+
+      document.getElementById('importFlags').click()
+    },
+    importFlagsChanged (e) {
+      const file = e.target.files[0];
+
+      if (file.type !== 'application/json') {
+        console.info('Import flags supports only JSON format, please upload a new file')
+        return;
+      }
+
+      const fileReader = new FileReader()
+      fileReader.onload = this.onFileReaderLoaded
+      fileReader.readAsText(file)
     }
   }
 }
@@ -193,6 +237,12 @@ export default {
   .el-table__row {
     cursor: pointer;
   }
+  .import-btn {
+    margin-left: 10px;
+  }
+  // .import-flags-input {
+  //   display: none;
+  // }
 }
 
 </style>

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -30,28 +30,7 @@
           </el-row>
 
           <el-row>
-            <el-button
-              type="primary"
-              icon="el-icon-caret-bottom"
-              v-on:click="exportFlags"
-            >
-              Export all flags
-            </el-button>
-            <a ref="exportFile"/>
-
-            <el-button
-              class="import-btn"
-              icon="el-icon-upload2"
-              @click="importFlags"
-            >
-              Import flags
-            </el-button>
-            <input
-              type="file"
-              hidden
-              id="importFlags"
-              @change="importFlagsChanged"
-            />
+            <import-export-flags :flags="this.flags" class="import-export-flags"></import-export-flags>
           </el-row>
 
           <el-table
@@ -112,6 +91,7 @@ import Axios from 'axios'
 
 import constants from '@/constants'
 import Spinner from '@/components/Spinner'
+import ImportExportFlags from '@/components/ImportExportFlags'
 import helpers from '@/helpers/helpers'
 
 const {
@@ -125,7 +105,8 @@ const {
 export default {
   name: 'flags',
   components: {
-    spinner: Spinner
+    spinner: Spinner,
+    ImportExportFlags
   },
   data () {
     return {
@@ -170,60 +151,6 @@ export default {
           this.flags.unshift(flag)
         }, handleErr.bind(this))
     },
-    async getFlag (flagId) {
-      const { data } = await Axios.get(`${API_URL}/flags/${flagId}`)
-      return data;
-    },
-    async getAllFlags () {
-      const flagIds = this.flags.map(flag => flag.id)
-      const getAllFlagsTasks = flagIds.map(this.getFlag)
-      const flags = await Promise.all(getAllFlagsTasks)
-
-      return flags
-    },
-    async exportFlags () {
-      const exportFileHref = this.$refs.exportFile
-      const flagsText = await this.getAllFlags()
-
-      exportFileHref.setAttribute(
-        "href",
-        "data:text/plain;charset=utf-8," + encodeURIComponent(JSON.stringify(flagsText))
-      );
-      exportFileHref.setAttribute("download", 'flags.json');
-      exportFileHref.click();
-    },
-    onFileReaderLoaded (loadedFile) {
-      const fileContent = loadedFile.target.result;
-
-      try {
-        const flags = JSON.parse(fileContent);
-        debugger
-      }
-      catch (err) {
-        console.error('Failed to load flags from file', err)
-      }
-    },
-    importFlags (e) {
-      e.preventDefault()
-      if (!window.FileReader) {
-        console.info('Reading files is not supported for that browser. Please try using anthor one.')
-        return;
-      }
-
-      document.getElementById('importFlags').click()
-    },
-    importFlagsChanged (e) {
-      const file = e.target.files[0];
-
-      if (file.type !== 'application/json') {
-        console.info('Import flags supports only JSON format, please upload a new file')
-        return;
-      }
-
-      const fileReader = new FileReader()
-      fileReader.onload = this.onFileReaderLoaded
-      fileReader.readAsText(file)
-    }
   }
 }
 </script>
@@ -237,12 +164,9 @@ export default {
   .el-table__row {
     cursor: pointer;
   }
-  .import-btn {
-    margin-left: 10px;
+  .import-export-flags {
+    margin-top: 5px;
   }
-  // .import-flags-input {
-  //   display: none;
-  // }
 }
 
 </style>

--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -29,6 +29,19 @@
             </el-col>
           </el-row>
 
+          <el-row>
+            <el-col>
+              <el-button
+                type="primary"
+                icon="el-icon-caret-bottom"
+                v-on:click="exportFlags"
+              >
+                Export all flags
+              </el-button>
+              <a ref="exportFile"/>
+            </el-col>
+          </el-row>
+
           <el-table
             :data="flags"
             :stripe="true"
@@ -144,6 +157,28 @@ export default {
           flag._new = true
           this.flags.unshift(flag)
         }, handleErr.bind(this))
+    },
+    async getFlag (flagId) {
+      const { data } = await Axios.get(`${API_URL}/flags/${flagId}`)
+      return data;
+    },
+    async getAllFlags () {
+      const flagIds = this.flags.map(flag => flag.id)
+      const getAllFlagsTasks = flagIds.map(this.getFlag)
+      const flags = await Promise.all(getAllFlagsTasks)
+
+      return flags
+    },
+    async exportFlags () {
+      const exportFileHref = this.$refs.exportFile
+      const flagsText = await this.getAllFlags()
+
+      exportFileHref.setAttribute(
+        "href",
+        "data:text/plain;charset=utf-8," + encodeURIComponent(JSON.stringify(flagsText))
+      );
+      exportFileHref.setAttribute("download", 'flags.json');
+      exportFileHref.click();
     }
   }
 }

--- a/browser/flagr-ui/src/components/ImportExportFlags.vue
+++ b/browser/flagr-ui/src/components/ImportExportFlags.vue
@@ -19,7 +19,7 @@ const { API_URL } = constants;
 
 export default {
   name: "import-export-flags",
-  props: ["flags"],
+  props: ["flags", "loadFlags"],
   data () {
     return {
       importFlagsInProcess: false,
@@ -181,11 +181,10 @@ export default {
 
       try {
         flags = JSON.parse(fileContent);
-        console.log("start import process");
         this.importFlagsInProcess = true;
         await Promise.all(flags.map(this.createFlagWithMetadata));
         this.importFlagsInProcess = false;
-        console.log("finished import process succesfully!");
+        this.loadFlags()
       } catch (err) {
         if (!flags) {
           console.error("Failed to load flags from file", err);

--- a/browser/flagr-ui/src/components/ImportExportFlags.vue
+++ b/browser/flagr-ui/src/components/ImportExportFlags.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="import-export-flags-container">
+    <el-button type="primary" icon="el-icon-caret-bottom" v-on:click="exportFlags">Export all flags</el-button>
+    <a ref="exportFile"/>
+
+    <el-button class="import-btn" icon="el-icon-upload2" @click="importFlags">Import flags</el-button>
+    <input type="file" hidden id="importFlags" @change="importFlagsChanged">
+  </div>
+</template>
+
+<script>
+import Axios from "axios";
+import constants from "@/constants";
+
+const { API_URL } = constants;
+
+export default {
+  name: "import-export-flags",
+  props: ["flags"],
+  methods: {
+    async getFlag(flagId) {
+      const { data } = await Axios.get(`${API_URL}/flags/${flagId}`);
+      return data;
+    },
+    async getAllFlags() {
+      const flagIds = this.flags.map(flag => flag.id);
+      const getAllFlagsTasks = flagIds.map(this.getFlag);
+      const flags = await Promise.all(getAllFlagsTasks);
+
+      return flags;
+    },
+    async exportFlags() {
+      const exportFileHref = this.$refs.exportFile;
+      const flagsText = await this.getAllFlags();
+
+      exportFileHref.setAttribute(
+        "href",
+        "data:text/plain;charset=utf-8," +
+          encodeURIComponent(JSON.stringify(flagsText))
+      );
+      exportFileHref.setAttribute("download", "flags.json");
+      exportFileHref.click();
+    },
+    onFileReaderLoaded(loadedFile) {
+      const fileContent = loadedFile.target.result;
+
+      try {
+        const flags = JSON.parse(fileContent);
+        debugger;
+      } catch (err) {
+        console.error("Failed to load flags from file", err);
+      }
+    },
+    importFlags(e) {
+      e.preventDefault();
+      if (!window.FileReader) {
+        console.info(
+          "Reading files is not supported for that browser. Please try using anthor one."
+        );
+        return;
+      }
+
+      document.getElementById("importFlags").click();
+    },
+    importFlagsChanged(e) {
+      const file = e.target.files[0];
+
+      if (file.type !== "application/json") {
+        console.info(
+          "Import flags supports only JSON format, please upload a new file"
+        );
+        return;
+      }
+
+      const fileReader = new FileReader();
+      fileReader.onload = this.onFileReaderLoaded;
+      fileReader.readAsText(file);
+    }
+  }
+};
+</script>
+
+<style lang="less" scoped>
+.import-export-flags-container {
+  .import-btn {
+    margin-left: 10px;
+  }
+}
+</style>

--- a/browser/flagr-ui/src/components/ImportExportFlags.vue
+++ b/browser/flagr-ui/src/components/ImportExportFlags.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="import-export-flags-container">
+    <div v-if="importFlagsInProcess">
+      Proccessing flags from files in work...
+    </div>
     <el-button type="primary" icon="el-icon-caret-bottom" v-on:click="exportFlags">Export all flags</el-button>
     <a ref="exportFile"/>
 
@@ -9,14 +12,19 @@
 </template>
 
 <script>
-import Axios from "axios";
-import constants from "@/constants";
+import Axios from 'axios';
+import constants from '@/constants';
 
 const { API_URL } = constants;
 
 export default {
   name: "import-export-flags",
   props: ["flags"],
+  data () {
+    return {
+      importFlagsInProcess: false,
+    }
+  },
   methods: {
     async getFlag(flagId) {
       const { data } = await Axios.get(`${API_URL}/flags/${flagId}`);
@@ -41,14 +49,149 @@ export default {
       exportFileHref.setAttribute("download", "flags.json");
       exportFileHref.click();
     },
-    onFileReaderLoaded(loadedFile) {
-      const fileContent = loadedFile.target.result;
+    createFlag(flag) {
+      return Axios.post(`${API_URL}/flags`, {
+        description: flag.description,
+        key: flag.key
+      });
+    },
+    updateFlagMetadata(flag, newFlagId) {
+      const { dataRecordsEnabled, enabled, key, notes, entityType } = flag;
+
+      return Axios.put(`${API_URL}/flags/${newFlagId}`, {
+        dataRecordsEnabled,
+        enabled,
+        key,
+        notes,
+        entityType
+      });
+    },
+    async createSegmentWithConstraints(segment, newFlagId, newVariants) {
+      const {
+        constraints,
+        description,
+        rolloutPercent,
+        distributions
+      } = segment;
+
+      // 1. create segment
+      const { data: createdSegment } = await Axios.post(
+        `${API_URL}/flags/${newFlagId}/segments`,
+        {
+          description,
+          rolloutPercent
+        }
+      );
+
+      // 2. put constarints
+      await Promise.all(
+        constraints.map(({ id, ...propsToSend }) =>
+          Axios.post(
+            `${API_URL}/flags/${newFlagId}/segments/${
+              createdSegment.id
+            }/constraints`,
+            {
+              ...propsToSend // (property, operator, value)
+            }
+          )
+        )
+      );
+
+      // since distributions points to non exsiting variant keys, we have to
+      // update the data by newVariants
+      const distributionsWithUpdatedVariantIds = distributions.map(
+        ({ percent, variantKey }) => {
+          const matchedVariant = newVariants.find(
+            variant => variant.key === variantKey
+          );
+
+          if (!matchedVariant) {
+            console.error("Could not find match for variant id", variantKey);
+          }
+
+          return {
+            percent,
+            variantKey,
+            variantID: matchedVariant.id
+          };
+        }
+      );
+
+      // 3. put distribution
+      await Axios.put(
+        `${API_URL}/flags/${newFlagId}/segments/${
+          createdSegment.id
+        }/distributions`,
+        {
+          distributions: distributionsWithUpdatedVariantIds
+        }
+      );
+    },
+    async createSegments(segments, newFlagId, newVariants) {
+      if (!segments) {
+        return;
+      }
+
+      return Promise.all(
+        segments.map(segment =>
+          this.createSegmentWithConstraints(segment, newFlagId, newVariants)
+        )
+      );
+    },
+    async createVariants(variants, newFlagId) {
+      const responses = await Promise.all(
+        variants.map(({ key, attachment }) =>
+          Axios.post(`${API_URL}/flags/${newFlagId}/variants`, {
+            key,
+            attachment
+          })
+        )
+      );
+
+      return responses.map(res => res.data);
+    },
+    async createFlagWithMetadata(flag) {
+      const matchedFlag = this.flags.find(
+        existingFlag =>
+          existingFlag.id === flag.id ||
+          existingFlag.description === flag.description
+      );
+
+      if (matchedFlag) {
+        return;
+      }
+
+      const { segments, variants } = flag;
 
       try {
-        const flags = JSON.parse(fileContent);
-        debugger;
+        const { data: newFlag } = await this.createFlag(flag);
+        await this.updateFlagMetadata(flag, newFlag.id);
+        const newVariants = await this.createVariants(
+          variants,
+          newFlag.id
+        );
+        await this.createSegments(segments, newFlag.id, newVariants); // TODO
+      } catch (error) {
+        console.error('Failed to create flag', error);
+      }
+    },
+    async onFileReaderLoaded(loadedFile) {
+      const fileContent = loadedFile.target.result;
+      let flags;
+
+      try {
+        flags = JSON.parse(fileContent);
+        console.log("start import process");
+        this.importFlagsInProcess = true;
+        await Promise.all(flags.map(this.createFlagWithMetadata));
+        this.importFlagsInProcess = false;
+        console.log("finished import process succesfully!");
       } catch (err) {
-        console.error("Failed to load flags from file", err);
+        if (!flags) {
+          console.error("Failed to load flags from file", err);
+        } else {
+          console.error("Failed to update/create flag", err);
+        }
       }
     },
     importFlags(e) {


### PR DESCRIPTION
The changes in this PR are about adding the capability of import/export flags into the system.

## Description
I thought that it can be handy to copy flags from different environments and to enable an easy way to bootstrap the system from flags list.

![import flags](https://user-images.githubusercontent.com/13322290/60300567-ed992b00-9937-11e9-8618-83a0625436ab.gif)

## Motivation and Context
I tend to use flagr in two different environments - DEV and PROD. When I need to add a new flag, first I add it to DEV, then create the same flag manually in PROD. I found it useful to automate the process I tend to do and make it easier to use this library.

## How Has This Been Tested?
Locally, manually.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.