### PR TITLE
Oidc key discovery support

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -185,6 +185,9 @@ var Config = struct {
 	// "HS256" and "RS256" supported
 	JWTAuthSigningMethod string `env:"FLAGR_JWT_AUTH_SIGNING_METHOD" envDefault:"HS256"`
 
+	// Verify the JWT through OIDC flows
+	JWTAuthOIDCWellKnownURL string `env:"FLAGR_JWT_AUTH_OIDC_WELL_KNOWN_URL" envDefault:""`
+
 	// Identify users through headers
 	HeaderAuthEnabled   bool   `env:"FLAGR_HEADER_AUTH_ENABLED" envDefault:"false"`
 	HeaderAuthUserField string `env:"FLAGR_HEADER_AUTH_USER_FIELD" envDefault:"X-Email"`

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -188,10 +188,6 @@ func setupJWTAuthMiddleware() *jwtAuth {
 				return "", err
 			}
 
-			if err != nil {
-				return "", err
-			}
-
 			// Read in the jwks and unmarshall it.
 			defer oidcJwksResp.Body.Close()
 			body, err = ioutil.ReadAll(oidcJwksResp.Body)

--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -250,7 +250,6 @@ func calculateJWTSigningKey(jwk *OidcJwk) (interface{}, error) {
 	}
 
 	// Decode the modulus and move it into a big int.
-	logrus.Printf("Modulus found: " + jwk.Modulus)
 	decN, err := base64.RawURLEncoding.DecodeString(jwk.Modulus)
 	if err != nil {
 		logrus.Errorf("Failed to decode modulus string.")
@@ -260,7 +259,6 @@ func calculateJWTSigningKey(jwk *OidcJwk) (interface{}, error) {
 	n.SetBytes(decN)
 
 	// Decode the exponent
-	logrus.Printf("Exponent found: " + jwk.Exponent)
 	eStr := jwk.Exponent
 	decE, err := base64.RawURLEncoding.DecodeString(eStr)
 	if err != nil {
@@ -283,7 +281,6 @@ func calculateJWTSigningKey(jwk *OidcJwk) (interface{}, error) {
 		return "", err
 	}
 	pKey := &rsa.PublicKey{N: n, E: int(e)}
-	logrus.Printf("Created public key.")
 	return pKey, nil
 }
 


### PR DESCRIPTION
Adding support for validating JWTs from OAuth2 providers using OIDC key discovery. 

## Description
A very popular way of getting JWTs to authenticate users are to get them from OAuth2 providers, and many use OIDC these days. OIDC is a protocol to discover the public signing keys for a JWT so that they can rotate/remove signing keys should they become compromised. This update extends the validation key getter methods to do this key discovery, per the instructions from the root package. 

## Motivation and Context
Allows JWTs issued by OAuth2 providers that use OIDC to be used and validated by Flagr.

## How Has This Been Tested?
I have tested this using Azure Active Directory issued JWTs, and with Okta, a very popular OAuth2 provider used by companies to internally lock down access. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project. (I'm unsure about this, I'm relatively new to Go)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (I'm not sure how to unit test this since any statically created JWT would have it's signing key potentially removed over time)
- [x] All new and existing tests passed.