### PR TITLE
Add server-side information to evaluation EntityContext

### DIFF
--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -11,7 +11,7 @@ The definitions of the following concepts are in [API doc](https://checkr.github
 - **Segment** represents the segmentation, i.e. the set of audience we want to target. Segment is the smallest unit of a component we can analyze in Flagr Metrics.
 - **Constraint** represents rules that we can use to define the audience of the segment. In other words, the audience in the segment is defined by a set of constraints. Specifically, in Flagr, the constraints are connected with `AND` in a segment.
 - **Distribution** represents the distribution of variants in a segment.
-- **Entity** represents the context of what we are going to assign the variant on. Usually, Flagr expects the context coming with the entity, so that one can define constraints based on the context of the entity.
+- **Entity** represents the context of what we are going to assign the variant on, consisting of an ID, type, and additional optional properties (context).  To evaluate constraints, Flagr uses the incoming entity context and adds properties for @entityID, @entityType, and any additional properties defined by the server configuration.
 - **Rollout** and deterministic random logic. The goal here is to ensure deterministic and persistent evaluation result for entities. Steps to evaluating a flag given an entity context:
     - Take the unique ID from the entity, hash it using a hash function that has a uniform distribution (e.g. CRC32, MD5).
     - Take the hash value (base 10) and mod 1000. 1000 is the total number of buckets used in Flagr.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,11 +1,44 @@
 package config
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSetupConfig(t *testing.T) {
+	nonsense := "asdf;lkj"
+	orig := os.Getenv("HOST")
+	err := os.Setenv("HOST", nonsense)
+	assert.Nil(t, err)
+
+	setupConfig()
+	assert.Equal(t, nonsense, Config.Host)
+	err = os.Setenv("HOST", orig)
+	assert.Nil(t, err)
+}
+
+func TestParseServerEntityContextConfig(t *testing.T) {
+	serverEntityContext := map[string]string{
+		"foo": "bar",
+	}
+	serverEntityContextBytes, err := json.Marshal(serverEntityContext)
+	assert.Nil(t, err)
+	serverEntityContextJson := string(serverEntityContextBytes)
+
+	orig := os.Getenv("FLAGR_EVAL_SERVER_ENTITY_CONTEXT")
+	err = os.Setenv("FLAGR_EVAL_SERVER_ENTITY_CONTEXT", serverEntityContextJson)
+	assert.Nil(t, err)
+
+	setupConfig()
+	assert.Equal(t, serverEntityContext, Config.EvalServerEntityContext)
+	assert.Equal(t, "bar", Config.EvalServerEntityContext["foo"])
+	err = os.Setenv("FLAGR_EVAL_SERVER_ENTITY_CONTEXT", orig)
+	assert.Nil(t, err)
+}
 
 func TestSetupSentry(t *testing.T) {
 	Config.SentryEnabled = true

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -42,6 +42,8 @@ var Config = struct {
 	// EvalOnlyMode - will only expose the evaluation related endpoints.
 	// This field will be derived from DBDriver
 	EvalOnlyMode bool `env:"FLAGR_EVAL_ONLY_MODE" envDefault:"false"`
+	// additional values to put in EntityContext when evaluating segments
+	EvalServerEntityContext map[string]string `env:"FLAGR_EVAL_SERVER_ENTITY_CONTEXT" envDefault:"{}"`
 
 	/**
 	DBDriver and DBConnectionStr define how we can write and read flags data.
@@ -151,7 +153,7 @@ var Config = struct {
 	RecorderKinesisFlushInterval       time.Duration `env:"FLAGR_RECORDER_KINESIS_FLUSH_INTERVAL" envDefault:"5s"`
 	RecorderKinesisBatchCount          int           `env:"FLAGR_RECORDER_KINESIS_BATCH_COUNT" envDefault:"500"`
 	RecorderKinesisBatchSize           int           `env:"FLAGR_RECORDER_KINESIS_BATCH_SIZE" envDefault:"0"`
-	RecorderKinesisAggregateBatchCount int           `env:"FLAGR_RECORDER_KINESIS_AGGREGATE_BATCH_COUNT" envDefault:"4294967295"`
+	RecorderKinesisAggregateBatchCount int           `env:"FLAGR_RECORDER_KINESIS_AGGREGATE_BATCH_COUNT" envDefault:"2147483647"`
 	RecorderKinesisAggregateBatchSize  int           `env:"FLAGR_RECORDER_KINESIS_AGGREGATE_BATCH_SIZE" envDefault:"51200"`
 	RecorderKinesisVerbose             bool          `env:"FLAGR_RECORDER_KINESIS_VERBOSE" envDefault:"false"`
 

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -42,8 +42,22 @@ var Config = struct {
 	// EvalOnlyMode - will only expose the evaluation related endpoints.
 	// This field will be derived from DBDriver
 	EvalOnlyMode bool `env:"FLAGR_EVAL_ONLY_MODE" envDefault:"false"`
-	// additional values to put in EntityContext when evaluating segments
-	EvalServerEntityContext map[string]string `env:"FLAGR_EVAL_SERVER_ENTITY_CONTEXT" envDefault:"{}"`
+	/**
+	FLAGR_EVAL_SERVER_ENTITY_CONTEXT is used to add additional key / value pairs to the
+	entity context when evaluating what flag segment to assign for an entity. To use this, set
+	the env var FLAGR_EVAL_SERVER_ENTITY_CONTEXT to a json reprsentation of the
+	key / value pairs you want to use, and the keys (with '@' prepended) will be made
+	available to use in segment constraints.
+	For example, if you set FLAGR_EVAL_SERVER_ENTITY_CONTEXT={"state": "NY"}, then
+	you can have a segment that checks if property '@state' in ["NY", "CA"] and it would match,
+	but a segment with '@state' in ["PA"] would not match.
+
+	This can be especially handy in the case that FLAGR_DB_DBDRIVER is json_http, where flagr fetches
+	the flag DB from a shared location and then performs evaluation locally. In this way your local
+	flagr server can add extra evaluation context with EvalServerEntityContext, and these values
+	don't have to be sent by the client.
+	*/
+	EvalServerEntityContext map[string]string `env:"EvalServerEntityContext" envDefault:"{}"`
 
 	/**
 	DBDriver and DBConnectionStr define how we can write and read flags data.

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -57,7 +57,7 @@ var Config = struct {
 	flagr server can add extra evaluation context with EvalServerEntityContext, and these values
 	don't have to be sent by the client.
 	*/
-	EvalServerEntityContext map[string]string `env:"EvalServerEntityContext" envDefault:"{}"`
+	EvalServerEntityContext map[string]string `env:"FLAGR_EVAL_SERVER_ENTITY_CONTEXT" envDefault:"{}"`
 
 	/**
 	DBDriver and DBConnectionStr define how we can write and read flags data.

--- a/pkg/entity/fixture.go
+++ b/pkg/entity/fixture.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"fmt"
+
 	"github.com/checkr/flagr/swagger_gen/models"
 
 	"github.com/jinzhu/gorm"
@@ -58,6 +60,50 @@ func GenFixtureSegment() Segment {
 				Property:  "dl_state",
 				Operator:  models.ConstraintOperatorEQ,
 				Value:     `"CA"`,
+			},
+		},
+		Distributions: []Distribution{
+			{
+				Model:      gorm.Model{ID: 400},
+				SegmentID:  200,
+				VariantID:  300,
+				VariantKey: "control",
+				Percent:    50,
+			},
+			{
+				Model:      gorm.Model{ID: 401},
+				SegmentID:  200,
+				VariantID:  301,
+				VariantKey: "treatment",
+				Percent:    50,
+			},
+		},
+	}
+	s.PrepareEvaluation()
+	return s
+}
+
+func GenFixtureSegmentWithEntityID(entityID string) Segment {
+	s := Segment{
+		Model:          gorm.Model{ID: 200},
+		FlagID:         100,
+		Description:    "",
+		Rank:           0,
+		RolloutPercent: 100,
+		Constraints: []Constraint{
+			{
+				Model:     gorm.Model{ID: 500},
+				SegmentID: 200,
+				Property:  "dl_state",
+				Operator:  models.ConstraintOperatorEQ,
+				Value:     `"CA"`,
+			},
+			{
+				Model:     gorm.Model{ID: 501},
+				SegmentID: 200,
+				Property:  "@entityID",
+				Operator:  models.ConstraintOperatorEQ,
+				Value:     fmt.Sprintf(`"%s"`, entityID),
 			},
 		},
 		Distributions: []Distribution{

--- a/pkg/entity/fixture.go
+++ b/pkg/entity/fixture.go
@@ -1,8 +1,6 @@
 package entity
 
 import (
-	"fmt"
-
 	"github.com/checkr/flagr/swagger_gen/models"
 
 	"github.com/jinzhu/gorm"
@@ -60,50 +58,6 @@ func GenFixtureSegment() Segment {
 				Property:  "dl_state",
 				Operator:  models.ConstraintOperatorEQ,
 				Value:     `"CA"`,
-			},
-		},
-		Distributions: []Distribution{
-			{
-				Model:      gorm.Model{ID: 400},
-				SegmentID:  200,
-				VariantID:  300,
-				VariantKey: "control",
-				Percent:    50,
-			},
-			{
-				Model:      gorm.Model{ID: 401},
-				SegmentID:  200,
-				VariantID:  301,
-				VariantKey: "treatment",
-				Percent:    50,
-			},
-		},
-	}
-	s.PrepareEvaluation()
-	return s
-}
-
-func GenFixtureSegmentWithAdditionalProperty(propertyName string, entityID string) Segment {
-	s := Segment{
-		Model:          gorm.Model{ID: 200},
-		FlagID:         100,
-		Description:    "",
-		Rank:           0,
-		RolloutPercent: 100,
-		Constraints: []Constraint{
-			{
-				Model:     gorm.Model{ID: 500},
-				SegmentID: 200,
-				Property:  "dl_state",
-				Operator:  models.ConstraintOperatorEQ,
-				Value:     `"CA"`,
-			},
-			{
-				Model:     gorm.Model{ID: 501},
-				SegmentID: 200,
-				Property:  propertyName,
-				Operator:  models.ConstraintOperatorEQ,
-				Value:     fmt.Sprintf(`"%s"`, entityID),
 			},
 		},
 		Distributions: []Distribution{

--- a/pkg/entity/fixture.go
+++ b/pkg/entity/fixture.go
@@ -83,7 +83,7 @@ func GenFixtureSegment() Segment {
 	return s
 }
 
-func GenFixtureSegmentWithEntityID(entityID string) Segment {
+func GenFixtureSegmentWithAdditionalProperty(propertyName string, entityID string) Segment {
 	s := Segment{
 		Model:          gorm.Model{ID: 200},
 		FlagID:         100,
@@ -101,7 +101,7 @@ func GenFixtureSegmentWithEntityID(entityID string) Segment {
 			{
 				Model:     gorm.Model{ID: 501},
 				SegmentID: 200,
-				Property:  "@entityID",
+				Property:  propertyName,
 				Operator:  models.ConstraintOperatorEQ,
 				Value:     fmt.Sprintf(`"%s"`, entityID),
 			},

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -276,6 +276,14 @@ var evalSegment = func(
 		m["@entityID"] = evalContext.EntityID
 		m["@entityType"] = evalContext.EntityType
 
+		for propertyName, value := range config.Config.EvalServerEntityContext {
+			if _, ok := m[propertyName]; ok {
+				continue
+			}
+			propertyKey := fmt.Sprintf("@%s", propertyName)
+			m[propertyKey] = value
+		}
+
 		expr := segment.SegmentEvaluation.ConditionsExpr
 		match, err := conditions.Evaluate(expr, m)
 		if err != nil {

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -273,6 +273,9 @@ var evalSegment = func(
 			return nil, log, true
 		}
 
+		m["@entityID"] = evalContext.EntityID
+		m["@entityType"] = evalContext.EntityType
+
 		expr := segment.SegmentEvaluation.ConditionsExpr
 		match, err := conditions.Evaluate(expr, m)
 		if err != nil {

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -81,6 +81,7 @@ func TestEvalSegment(t *testing.T) {
 		origEvalServerEntityContext := config.Config.EvalServerEntityContext
 		serverEntityContext := map[string]string{"foo": "bar"}
 		config.Config.EvalServerEntityContext = serverEntityContext
+		defer (func() { config.Config.EvalServerEntityContext = origEvalServerEntityContext })()
 
 		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
 			EnableDebug:   true,
@@ -89,8 +90,6 @@ func TestEvalSegment(t *testing.T) {
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
 		}, s)
-
-		config.Config.EvalServerEntityContext = origEvalServerEntityContext
 
 		assert.NotNil(t, vID)
 		assert.NotEmpty(t, log)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/checkr/flagr/pkg/config"
@@ -41,8 +42,16 @@ func TestEvalSegment(t *testing.T) {
 
 	t.Run("evalSegment attaches EvalContext members to EntityContext with '@' prefix", func(t *testing.T) {
 		entityID := "entityID1"
-		s := entity.GenFixtureSegmentWithAdditionalProperty("@entityID", entityID)
+		s := entity.GenFixtureSegment()
+		s.Constraints = append(s.Constraints, entity.Constraint{
+			Model:     gorm.Model{ID: 501},
+			SegmentID: 200,
+			Property:  "@entityID",
+			Operator:  models.ConstraintOperatorEQ,
+			Value:     fmt.Sprintf(`"%s"`, entityID),
+		})
 		s.RolloutPercent = uint(100)
+		s.PrepareEvaluation()
 
 		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
 			EnableDebug:   true,
@@ -60,8 +69,16 @@ func TestEvalSegment(t *testing.T) {
 	t.Run("evalSegment attaches Config.EvalServerEntityContext to EntityContext", func(t *testing.T) {
 		serverEntityContext := map[string]string{"foo": "bar"}
 		config.Config.EvalServerEntityContext = serverEntityContext
-		s := entity.GenFixtureSegmentWithAdditionalProperty("@foo", "bar")
+		s := entity.GenFixtureSegment()
+		s.Constraints = append(s.Constraints, entity.Constraint{
+			Model:     gorm.Model{ID: 501},
+			SegmentID: 200,
+			Property:  "@foo",
+			Operator:  models.ConstraintOperatorEQ,
+			Value:     `"bar"`,
+		})
 		s.RolloutPercent = uint(100)
+		s.PrepareEvaluation()
 
 		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
 			EnableDebug:   true,

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -38,6 +38,24 @@ func TestEvalSegment(t *testing.T) {
 		assert.False(t, evalNextSegment)
 	})
 
+	t.Run("evalSegment attaches EvalContext members to EntityContext with '@' prefix", func(t *testing.T) {
+		entityID := "entityID1"
+		s := entity.GenFixtureSegmentWithEntityID(entityID)
+		s.RolloutPercent = uint(100)
+
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]interface{}{"dl_state": "CA"},
+			EntityID:      entityID,
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		}, s)
+
+		assert.NotNil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.False(t, evalNextSegment)
+	})
+
 	t.Run("test constraint evaluation error", func(t *testing.T) {
 		s := entity.GenFixtureSegment()
 		s.RolloutPercent = uint(100)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -67,8 +67,6 @@ func TestEvalSegment(t *testing.T) {
 	})
 
 	t.Run("evalSegment attaches Config.EvalServerEntityContext to EntityContext", func(t *testing.T) {
-		serverEntityContext := map[string]string{"foo": "bar"}
-		config.Config.EvalServerEntityContext = serverEntityContext
 		s := entity.GenFixtureSegment()
 		s.Constraints = append(s.Constraints, entity.Constraint{
 			Model:     gorm.Model{ID: 501},
@@ -80,6 +78,10 @@ func TestEvalSegment(t *testing.T) {
 		s.RolloutPercent = uint(100)
 		s.PrepareEvaluation()
 
+		origEvalServerEntityContext := config.Config.EvalServerEntityContext
+		serverEntityContext := map[string]string{"foo": "bar"}
+		config.Config.EvalServerEntityContext = serverEntityContext
+
 		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
@@ -87,6 +89,8 @@ func TestEvalSegment(t *testing.T) {
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
 		}, s)
+
+		config.Config.EvalServerEntityContext = origEvalServerEntityContext
 
 		assert.NotNil(t, vID)
 		assert.NotEmpty(t, log)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"testing"
 
+	"github.com/checkr/flagr/pkg/config"
 	"github.com/checkr/flagr/pkg/entity"
 	"github.com/checkr/flagr/swagger_gen/models"
 	"github.com/checkr/flagr/swagger_gen/restapi/operations/evaluation"
@@ -40,13 +41,32 @@ func TestEvalSegment(t *testing.T) {
 
 	t.Run("evalSegment attaches EvalContext members to EntityContext with '@' prefix", func(t *testing.T) {
 		entityID := "entityID1"
-		s := entity.GenFixtureSegmentWithEntityID(entityID)
+		s := entity.GenFixtureSegmentWithAdditionalProperty("@entityID", entityID)
 		s.RolloutPercent = uint(100)
 
 		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
 			EnableDebug:   true,
 			EntityContext: map[string]interface{}{"dl_state": "CA"},
 			EntityID:      entityID,
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		}, s)
+
+		assert.NotNil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.False(t, evalNextSegment)
+	})
+
+	t.Run("evalSegment attaches Config.EvalServerEntityContext to EntityContext", func(t *testing.T) {
+		serverEntityContext := map[string]string{"foo": "bar"}
+		config.Config.EvalServerEntityContext = serverEntityContext
+		s := entity.GenFixtureSegmentWithAdditionalProperty("@foo", "bar")
+		s.RolloutPercent = uint(100)
+
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]interface{}{"dl_state": "CA"},
+			EntityID:      "entityID1",
 			EntityType:    "entityType1",
 			FlagID:        int64(100),
 		}, s)

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -443,6 +443,7 @@ definitions:
         type: string
       entityContext:
         type: object
+        description: Key / value pairs representing properties of the entity that can be used to evaluate segment constraints.  The Flagr evaluation engine also adds @entityID, @entityType, and any additional properties from the its EvalServerEntityContext configuration.
       enableDebug:
         type: boolean
       flagID:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR sets up options to add additional properties to the `EntityContext` that is used when evaluating which segment on the flag matches the incoming criteria.  Each additional property that is added on the server side is prefixed with '@' to differentiate it from the original client context.  There are two types added: 
- values from the `EvalContext` but aren't available on the `EntityContext`, which might be useful or convenient (e.g. `@entityID` and `@entityType`)
- additional properties configured from the server config / environment - the user may provide a JSON map in the env variable `FLAGR_EVAL_SERVER_ENTITY_CONTEXT` to add these additional properties



## Motivation and Context
https://github.com/checkr/flagr/issues/322

As mentioned in the issue, one case is where you want to pick different variants based on the entity ID provided; in this case the PR change makes it so you don't have to specify the entityID twice in the request.

I added the additional config properties because of the following use case.  We have multiple deployments of flagr (one per 'environment') that use the same flag DB (for configuration management reasons).  Our client requests send up an `env` property in the `EntityContext`, but this means that all our clients have to be configured for that.  If the server specifies the env value, we only have to specify it in the server environment rather than in multiple clients. 

## How Has This Been Tested?
I've only tested it by adding specific go tests so far; I wanted to put up the PR and get feedback.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
   - potentially if someone is using `EntityContext` properties with an `@` prefix this  change could result in different behavior
   - it also changed the default value of the `FLAGR_RECORDER_KINESIS_AGGREGATE_BATCH_COUNT` config value, because the parser properly validated that the previous default value does not fit into an `int` variable.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.