### PR TITLE
Customizable validation rules for enabled flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: deps gen build build_ui run
 rebuild: gen build
 
 test: verifiers
-	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/handler
+	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/...
 
 .PHONY: benchmark
 benchmark:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build_ui:
 run_ui:
 	@cd ./browser/flagr-ui/; npm run serve
 
-run:
+run: build
 	@$(PWD)/flagr --port 18000
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,8 @@ all: deps gen build build_ui run
 
 rebuild: gen build
 
-# test: verifiers
-test:
-	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/...
+test: verifiers
+	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/handler
 
 .PHONY: benchmark
 benchmark:
@@ -36,7 +35,7 @@ build_ui:
 run_ui:
 	@cd ./browser/flagr-ui/; npm run serve
 
-run:
+run: build
 	@$(PWD)/flagr --port 18000
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ rebuild: gen build
 
 # test: verifiers
 test:
-	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/handler
+	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/...
 
 .PHONY: benchmark
 benchmark:
@@ -36,7 +36,7 @@ build_ui:
 run_ui:
 	@cd ./browser/flagr-ui/; npm run serve
 
-run: build
+run:
 	@$(PWD)/flagr --port 18000
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ all: deps gen build build_ui run
 
 rebuild: gen build
 
-test: verifiers
-	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/...
+# test: verifiers
+test:
+	@GO111MODULE=on go test -mod=vendor -race -covermode=atomic -coverprofile=coverage.txt github.com/checkr/flagr/pkg/handler
 
 .PHONY: benchmark
 benchmark:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	cloud.google.com/go v0.37.4
 	github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a
+	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/Shopify/sarama v1.19.0
 	github.com/a8m/kinesis-producer v0.0.0-20180723062609-03228a9f79b3
 	github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7
@@ -19,6 +20,7 @@ require (
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/evalphobia/logrus_sentry v0.4.6
+	github.com/fatih/structs v1.1.0
 	github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03
 	github.com/go-openapi/errors v0.19.9
 	github.com/go-openapi/loads v0.20.1

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bsm/ratelimit v2.0.0+incompatible
 	github.com/caarlos0/env v3.3.0+incompatible
 	github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261 // indirect
+	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/codegangsta/negroni v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dchest/uniuri v0.0.0-20160212164326-8902c56451e9
@@ -34,6 +35,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jinzhu/gorm v1.9.16
 	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d // indirect
+	github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215
 	github.com/meatballhat/negroni-logrus v0.0.0-20170801195057-31067281800f
 	github.com/newrelic/go-agent v2.1.0+incompatible
 	github.com/onsi/ginkgo v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/caarlos0/env v3.3.0+incompatible h1:jCfY0ilpzC2FFViyZyDKCxKybDESTwaR+
 github.com/caarlos0/env v3.3.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261 h1:6/yVvBsKeAw05IUj4AzvrxaCnDjN4nUqKjW9+w5wixg=
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
+github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
+github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codegangsta/negroni v1.0.0 h1:+aYywywx4bnKXWvoWtRfJ91vC59NbEhEY03sZjQhbVY=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
@@ -316,6 +318,8 @@ github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
+github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215 h1:hDa3vAq/Zo5gjfJ46XMsGFbH+hTizpR4fUzQCk2nxgk=
+github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215/go.mod h1:LH+NgPY9AJpDfqAFtzyer01N9MYNsAKUf3DC9DV1xIY=
 github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/QA=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a h1:zpQSzEApXM0qkXcpdjeJ4OpnBWhD/X8zT/iT1wYLiVU=
 github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
+github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVkjK4=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -75,6 +77,8 @@ github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DP
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evalphobia/logrus_sentry v0.4.6 h1:825MLGu+SW5H8hMXGeBI7TwX7vgJLd9hz0Eth1Mnp3o=
 github.com/evalphobia/logrus_sentry v0.4.6/go.mod h1:pKcp+vriitUqu9KiWj/VRFbRfFNUwz95/UkgG8a6MNc=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03 h1:G/9fPivTr5EiyqE9OlW65iMRUxFXMGRHgZFGo50uG8Q=

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -217,6 +217,14 @@ var Config = struct {
 	// (putFlag or setFlagEnabled), the flag is evaluated against these
 	// optional rules. The operator indicates if all the rules must pass ('AND' value)
 	// or if at least one rule must pass ('OR' value)
+	//
+	// Example rule:
+	// FLAGR_ENABLED_FLAG_VALIDATION_RULES='any("regexMatch(Value, \"^JIRA:[a-zA-Z]{3}[a-zA-Z]*$\")", Tags)'
+	// this requires that the flag have at least one tag that matches a regex starting with 'JIRA:' and ending with a
+	// project name consisting of a-z characters, like 'EPLT'
+	//
+	// to use multiple rules, separate each rule with ':::'.
+	//
 	EnabledFlagValidationRules     []string `env:"FLAGR_ENABLED_FLAG_VALIDATION_RULES" envSeparator:":::"`
 	EnabledFlagValidationOperation string   `env:"FLAGR_ENABLED_FLAG_VALIDATION_OPERATOR" envDefault:"AND"`
 }{}

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -212,4 +212,14 @@ var Config = struct {
 	// UI path  => localhost:18000/foo"
 	// API path => localhost:18000/foo/api/v1"
 	WebPrefix string `env:"FLAGR_WEB_PREFIX" envDefault:""`
+
+	// rules for validating flags on enable - when a flag is updated or enabled
+	// (putFlag or setFlagEnabled), the flag is evaluated against these
+	// optional rules. The operator indicates if all the rules must pass ('AND' value)
+	// or if at least one rule must pass ('OR' value)
+	EnabledFlagValidationRules     []string `env:"FLAGR_ENABLED_FLAG_VALIDATION_RULES" envSeparator:","`
+	EnabledFlagValidationOperation string   `env:"FLAGR_ENABLED_FLAG_VALIDATION_OPERATOR" envDefault:"AND"`
 }{}
+
+const FlagValidationOperationOR = "OR"
+const FlagValidationOperationAND = "AND"

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -217,7 +217,7 @@ var Config = struct {
 	// (putFlag or setFlagEnabled), the flag is evaluated against these
 	// optional rules. The operator indicates if all the rules must pass ('AND' value)
 	// or if at least one rule must pass ('OR' value)
-	EnabledFlagValidationRules     []string `env:"FLAGR_ENABLED_FLAG_VALIDATION_RULES" envSeparator:","`
+	EnabledFlagValidationRules     []string `env:"FLAGR_ENABLED_FLAG_VALIDATION_RULES" envSeparator:":::"`
 	EnabledFlagValidationOperation string   `env:"FLAGR_ENABLED_FLAG_VALIDATION_OPERATOR" envDefault:"AND"`
 }{}
 

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -237,6 +237,16 @@ func (c *crud) PutFlag(params flag.PutFlagParams) middleware.Responder {
 		f.Notes = *params.Body.Notes
 	}
 
+	if f.Enabled {
+		valid, err := validateEnabledFlag(f)
+		if err != nil {
+			return flag.NewPutFlagDefault(500).WithPayload(ErrorMessage("%s", err))
+		}
+		if !valid {
+			return flag.NewPutFlagDefault(400).WithPayload(ErrorMessage("Flag failed enabled flag validation rules"))
+		}
+	}
+
 	if err := tx.Save(f).Error; err != nil {
 		return flag.NewPutFlagDefault(500).WithPayload(ErrorMessage("%s", err))
 	}
@@ -263,6 +273,16 @@ func (c *crud) SetFlagEnabledState(params flag.SetFlagEnabledParams) middleware.
 	}
 
 	f.Enabled = *params.Body.Enabled
+
+	if f.Enabled {
+		valid, err := validateEnabledFlag(f)
+		if err != nil {
+			return flag.NewPutFlagDefault(500).WithPayload(ErrorMessage("%s", err))
+		}
+		if !valid {
+			return flag.NewPutFlagDefault(400).WithPayload(ErrorMessage("Flag failed enabled flag validation rules"))
+		}
+	}
 
 	if err := getDB().Save(f).Error; err != nil {
 		return flag.NewSetFlagEnabledDefault(500).WithPayload(ErrorMessage("%s", err))

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -208,7 +208,7 @@ func (c *crud) PutFlag(params flag.PutFlagParams) middleware.Responder {
 	f := &entity.Flag{}
 	tx := getDB()
 
-	if err := tx.First(f, params.FlagID).Error; err != nil {
+	if err := entity.PreloadSegmentsVariantsTags(tx).First(f, params.FlagID).Error; err != nil {
 		return flag.NewPutFlagDefault(404).WithPayload(ErrorMessage("%s", err))
 	}
 
@@ -268,7 +268,7 @@ func (c *crud) PutFlag(params flag.PutFlagParams) middleware.Responder {
 
 func (c *crud) SetFlagEnabledState(params flag.SetFlagEnabledParams) middleware.Responder {
 	f := &entity.Flag{}
-	if err := getDB().First(f, params.FlagID).Error; err != nil {
+	if err := entity.PreloadSegmentsVariantsTags(getDB()).First(f, params.FlagID).Error; err != nil {
 		return flag.NewSetFlagEnabledDefault(404).WithPayload(ErrorMessage("%s", err))
 	}
 

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -237,14 +237,8 @@ func (c *crud) PutFlag(params flag.PutFlagParams) middleware.Responder {
 		f.Notes = *params.Body.Notes
 	}
 
-	if f.Enabled {
-		valid, err := validateEnabledFlag(f)
-		if err != nil {
-			return flag.NewPutFlagDefault(500).WithPayload(ErrorMessage("%s", err))
-		}
-		if !valid {
-			return flag.NewPutFlagDefault(400).WithPayload(ErrorMessage("Flag failed enabled flag validation rules"))
-		}
+	if err := validateFlagIfEnabled(f); err != nil {
+		return err
 	}
 
 	if err := tx.Save(f).Error; err != nil {
@@ -274,14 +268,8 @@ func (c *crud) SetFlagEnabledState(params flag.SetFlagEnabledParams) middleware.
 
 	f.Enabled = *params.Body.Enabled
 
-	if f.Enabled {
-		valid, err := validateEnabledFlag(f)
-		if err != nil {
-			return flag.NewPutFlagDefault(500).WithPayload(ErrorMessage("%s", err))
-		}
-		if !valid {
-			return flag.NewPutFlagDefault(400).WithPayload(ErrorMessage("Flag failed enabled flag validation rules"))
-		}
+	if err := validateFlagIfEnabled(f); err != nil {
+		return err
 	}
 
 	if err := getDB().Save(f).Error; err != nil {

--- a/pkg/handler/enabled_flag_validation.go
+++ b/pkg/handler/enabled_flag_validation.go
@@ -113,6 +113,7 @@ func Any(args ...interface{}) (interface{}, error) {
 		if !ok {
 			return false, fmt.Errorf("item is not a map %v", item)
 		}
+
 		result, err := expression.Evaluate(params)
 		if err != nil {
 			return false, err
@@ -160,6 +161,7 @@ func validateEnabledFlag(f *entity.Flag) (valid bool, err error) {
 
 	for _, validationRule := range evaluationRules {
 		params := structs.Map(f)
+
 		result, err := validationRule.Evaluate(params)
 		if err != nil {
 			return false, err

--- a/pkg/handler/enabled_flag_validation.go
+++ b/pkg/handler/enabled_flag_validation.go
@@ -15,13 +15,6 @@ import (
 	"github.com/matryer/resync"
 )
 
-// rules for validating flags on enable - when a flag is updated or enabled
-// (putFlag or setFlagEnabled), the flag is evaluated against these
-// optional rules. The operator indicates if all the rules must pass ('AND' value)
-// or if at least one rule must pass ('OR' value)
-// EnabledFlagValidationRules     []string `env:"FLAGR_ENABLED_FLAG_VALIDATION_RULES" envSeparator:","`
-// EnabledFlagValidationOperation string   `env:"FLAGR_ENABLED_FLAG_VALIDATION_OPERATOR" envDefault:"AND"`
-
 var (
 	evaluationRules           []*govaluate.EvaluableExpression
 	createEvaluationRule      resync.Once

--- a/pkg/handler/enabled_flag_validation.go
+++ b/pkg/handler/enabled_flag_validation.go
@@ -1,0 +1,186 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sync"
+
+	"github.com/Knetic/govaluate"
+	"github.com/checkr/flagr/pkg/config"
+	"github.com/checkr/flagr/pkg/entity"
+	"github.com/fatih/structs"
+)
+
+// rules for validating flags on enable - when a flag is updated or enabled
+// (putFlag or setFlagEnabled), the flag is evaluated against these
+// optional rules. The operator indicates if all the rules must pass ('AND' value)
+// or if at least one rule must pass ('OR' value)
+// EnabledFlagValidationRules     []string `env:"FLAGR_ENABLED_FLAG_VALIDATION_RULES" envSeparator:","`
+// EnabledFlagValidationOperation string   `env:"FLAGR_ENABLED_FLAG_VALIDATION_OPERATOR" envDefault:"AND"`
+
+var (
+	evaluationRules           []*govaluate.EvaluableExpression
+	createEvaluationRule      sync.Once
+	evaluationRulesSetupError error
+)
+
+/* with thanks to https://github.com/casbin/casbin/blob/d0d65d828c784211a47c23f9cc63b7429da0287e/util/builtin_operators.go */
+// validate the variadic parameter size and type as string
+func validateVariadicArgs(expectedLen int, args ...interface{}) error {
+	if len(args) != expectedLen {
+		return fmt.Errorf("Expected %d arguments, but got %d", expectedLen, len(args))
+	}
+
+	for _, p := range args {
+		_, ok := p.(string)
+		if !ok {
+			return errors.New("Argument must be a string")
+		}
+	}
+
+	return nil
+}
+
+// RegexMatch determines whether key1 matches the pattern of key2 in regular expression.
+func RegexMatch(key1 string, key2 string) (bool, error) {
+	res, err := regexp.MatchString(key2, key1)
+	if err != nil {
+		return false, err
+	}
+	return res, nil
+}
+
+// RegexMatchFunc is a govaluate function for matching regex,
+// it returns true if arg1 matches the regex pattern of arg2.
+func RegexMatchFunc(args ...interface{}) (interface{}, error) {
+	if err := validateVariadicArgs(2, args...); err != nil {
+		return false, fmt.Errorf("%s: %s", "regexMatch", err)
+	}
+
+	name1 := args[0].(string)
+	name2 := args[1].(string)
+
+	result, err := RegexMatch(name1, name2)
+	if err != nil {
+		return false, err
+	}
+
+	return result, nil
+}
+
+/* end 'with thanks to' */
+
+// THIS got weird when the params were in the other order (e.g. array, regex)
+// in this case it flattened the array into the args, e.g.
+// Any([1,2], /\d+/)
+// args = 1,2,/\d+/
+// putting it in regex, array order does not flatten it
+// args = /\d+/, [1,2]
+//
+// Govaluate function to evaluate an embedded govaluate expression (the first argument, a string)
+// for an array of 'items' (which should be a map[string]interface{}),
+// and if the subexpression returns true for any of the sub items
+// then the Any expression also returns true. It will early out once
+// it finds a single true result.
+func Any(args ...interface{}) (interface{}, error) {
+	if len(args) < 2 {
+		return false, fmt.Errorf("Expected 2+ arguments, but got %d", len(args))
+	}
+
+	function, ok := args[0].(string)
+	if !ok {
+		return false, fmt.Errorf("arg 0 is not a string!")
+	}
+
+	arr, ok := args[1].([]interface{})
+	if !ok {
+		return false, fmt.Errorf("arg 1 is not a slice! ***%v*** %v", args, reflect.TypeOf(args[0]))
+	}
+
+	functions := map[string]govaluate.ExpressionFunction{
+		"regexMatch": RegexMatchFunc,
+	}
+	expression, err := govaluate.NewEvaluableExpressionWithFunctions(function, functions)
+	if err != nil {
+		panic(err)
+	}
+
+	found := false
+	for _, item := range arr {
+		params, ok := item.(map[string]interface{})
+		if !ok {
+			return false, fmt.Errorf("item is not a map %v", item)
+		}
+		result, err := expression.Evaluate(params)
+		if err != nil {
+			panic(err)
+		}
+
+		if boolResult, ok := result.(bool); ok {
+			if boolResult {
+				found = true
+				break
+			}
+		}
+	}
+	return found, nil
+}
+
+func getEvaluationRules() ([]*govaluate.EvaluableExpression, error) {
+	createEvaluationRule.Do(func() {
+		for _, structExpressionString := range config.Config.EnabledFlagValidationRules {
+			functions := map[string]govaluate.ExpressionFunction{
+				"regexMatch": RegexMatchFunc,
+				"any":        Any,
+			}
+
+			expression, err := govaluate.NewEvaluableExpressionWithFunctions(structExpressionString, functions)
+			if expression == nil || err != nil {
+				evaluationRulesSetupError = err
+				return
+			}
+			evaluationRules = append(evaluationRules, expression)
+		}
+	})
+
+	return evaluationRules, evaluationRulesSetupError
+}
+
+func validateEnabledFlag(f *entity.Flag) (valid bool, err error) {
+	if config.Config.EnabledFlagValidationOperation == config.FlagValidationOperationAND {
+		valid = true
+	}
+
+	evaluationRules, err := getEvaluationRules()
+	if err != nil {
+		return false, err
+	}
+
+	for _, validationRule := range evaluationRules {
+		params := structs.Map(f)
+		result, err := validationRule.Evaluate(params)
+		if err != nil {
+			return false, err
+		}
+
+		resultBool, ok := result.(bool)
+		if !ok {
+			return false, fmt.Errorf("Unknown evaluation rule result type (%v)", result)
+		}
+
+		if config.Config.EnabledFlagValidationOperation == config.FlagValidationOperationOR {
+			valid = valid || resultBool
+			if valid {
+				break
+			}
+		} else if config.Config.EnabledFlagValidationOperation == config.FlagValidationOperationAND {
+			valid = valid && resultBool
+		} else {
+			return false, errors.New("Unknown FlagEnabledFlagValidationOperation - check server config")
+		}
+	}
+
+	return valid, nil
+}

--- a/pkg/handler/enabled_flag_validation_test.go
+++ b/pkg/handler/enabled_flag_validation_test.go
@@ -1,0 +1,1 @@
+package handler

--- a/pkg/handler/enabled_flag_validation_test.go
+++ b/pkg/handler/enabled_flag_validation_test.go
@@ -1,1 +1,117 @@
 package handler
+
+import (
+	"testing"
+
+	"github.com/checkr/flagr/pkg/config"
+	"github.com/checkr/flagr/pkg/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexMatchFuncNotStringArg1(t *testing.T) {
+	_, err := RegexMatchFunc(1, "foo")
+	assert.NotNil(t, err)
+}
+
+func TestRegexMatchFuncNotStringArg2(t *testing.T) {
+	_, err := RegexMatchFunc("foo", 1)
+	assert.NotNil(t, err)
+}
+
+func TestRegexMatchFuncMatching(t *testing.T) {
+	result, err := RegexMatchFunc("Bob", "\\w+")
+	assert.Nil(t, err)
+	assert.Equal(t, true, result)
+}
+
+func TestRegexMatchFuncNotMatching(t *testing.T) {
+	result, err := RegexMatchFunc("Bob", "\\d+")
+	assert.Nil(t, err)
+	assert.Equal(t, false, result)
+}
+
+func TestRegexMatchTooManyArgs(t *testing.T) {
+	_, err := RegexMatchFunc("Bob", "Frank", "Jim")
+	assert.NotNil(t, err)
+}
+
+func TestRegexMatchTooFewArgs(t *testing.T) {
+	_, err := RegexMatchFunc("Bob")
+	assert.NotNil(t, err)
+}
+
+func TestAnyTooFewArgs(t *testing.T) {
+	_, err := Any(1)
+	assert.NotNil(t, err)
+}
+
+func TestAnyArg0NotAString(t *testing.T) {
+	_, err := Any(1, 1)
+	assert.NotNil(t, err)
+}
+
+func TestAnyArg1NotASlice(t *testing.T) {
+	_, err := Any("foo", 1)
+	assert.NotNil(t, err)
+}
+
+func TestAnyMatch(t *testing.T) {
+	regexp := "regexMatch(Value, \"^JIRA:[a-zA-Z]{3}[a-zA-Z]*$\")"
+	slice := make([]interface{}, 0)
+	slice = append(slice, map[string]interface{}{"Value": "FOOBAR"})
+	slice = append(slice, map[string]interface{}{"Value": "JIRA:EPLT"})
+	result, err := Any(regexp, slice)
+	assert.Nil(t, err)
+	assert.Equal(t, true, result)
+}
+
+func TestAnyNoMatch(t *testing.T) {
+	regexp := "regexMatch(Value, \"^JIRA:[a-zA-Z]{3}[a-zA-Z]*$\")"
+	slice := make([]interface{}, 0)
+	slice = append(slice, map[string]interface{}{"Value": "FOOBAR"})
+	slice = append(slice, map[string]interface{}{"Value": "QUIX"})
+	result, err := Any(regexp, slice)
+	assert.Nil(t, err)
+	assert.Equal(t, false, result)
+}
+
+func setFlagValidationConfig(rules []string, operation string) (reset func()) {
+	old := config.Config
+	config.Config.EnabledFlagValidationRules = rules
+	config.Config.EnabledFlagValidationOperation = operation
+	createEvaluationRule.Reset()
+
+	return func() {
+		config.Config = old
+	}
+}
+func TestValidationEnabledFlag(t *testing.T) {
+	rules := []string{
+		`any("regexMatch(Value, \"^JIRA:[a-zA-Z]{3}[a-zA-Z]*$\")", Tags) `,
+	}
+	resetter := setFlagValidationConfig(rules, config.FlagValidationOperationAND)
+	defer resetter()
+
+	t.Run("valid tag will pass", func(t *testing.T) {
+		flag := &entity.Flag{
+			Tags: []entity.Tag{
+				{Value: "QUX"},
+				{Value: "JIRA:EPLT"},
+			},
+		}
+		result, err := validateEnabledFlag(flag)
+		assert.Nil(t, err)
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("invalid tag will fail", func(t *testing.T) {
+		flag := &entity.Flag{
+			Tags: []entity.Tag{
+				{Value: "QUX"},
+			},
+		}
+		result, err := validateEnabledFlag(flag)
+		assert.Nil(t, err)
+		assert.Equal(t, false, result)
+	})
+}

--- a/vendor/github.com/Knetic/govaluate/.gitignore
+++ b/vendor/github.com/Knetic/govaluate/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+coverage.out
+
+manual_test.go
+*.out
+*.err

--- a/vendor/github.com/Knetic/govaluate/.travis.yml
+++ b/vendor/github.com/Knetic/govaluate/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+script: ./test.sh
+
+go:
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6

--- a/vendor/github.com/Knetic/govaluate/CONTRIBUTORS
+++ b/vendor/github.com/Knetic/govaluate/CONTRIBUTORS
@@ -1,0 +1,12 @@
+This library was authored by George Lester, and contains contributions from:
+
+vjeantet (regex support)
+iasci (ternary operator)
+oxtoacart (parameter structures, deferred parameter retrieval)
+wmiller848 (bitwise operators)
+prashantv (optimization of bools)
+dpaolella (exposure of variables used in an expression)
+benpaxton (fix for missing type checks during literal elide process)
+abrander (panic-finding testing tool)
+xfennec (fix for dates being parsed in the current Location)
+bgaifullin (lifting restriction on complex/struct types)

--- a/vendor/github.com/Knetic/govaluate/EvaluableExpression.go
+++ b/vendor/github.com/Knetic/govaluate/EvaluableExpression.go
@@ -1,0 +1,272 @@
+package govaluate
+
+import (
+	"errors"
+	"fmt"
+)
+
+const isoDateFormat string = "2006-01-02T15:04:05.999999999Z0700"
+const shortCircuitHolder int = -1
+
+var DUMMY_PARAMETERS = MapParameters(map[string]interface{}{})
+
+/*
+	EvaluableExpression represents a set of ExpressionTokens which, taken together,
+	are an expression that can be evaluated down into a single value.
+*/
+type EvaluableExpression struct {
+
+	/*
+		Represents the query format used to output dates. Typically only used when creating SQL or Mongo queries from an expression.
+		Defaults to the complete ISO8601 format, including nanoseconds.
+	*/
+	QueryDateFormat string
+
+	/*
+		Whether or not to safely check types when evaluating.
+		If true, this library will return error messages when invalid types are used.
+		If false, the library will panic when operators encounter types they can't use.
+
+		This is exclusively for users who need to squeeze every ounce of speed out of the library as they can,
+		and you should only set this to false if you know exactly what you're doing.
+	*/
+	ChecksTypes bool
+
+	tokens           []ExpressionToken
+	evaluationStages *evaluationStage
+	inputExpression  string
+}
+
+/*
+	Parses a new EvaluableExpression from the given [expression] string.
+	Returns an error if the given expression has invalid syntax.
+*/
+func NewEvaluableExpression(expression string) (*EvaluableExpression, error) {
+
+	functions := make(map[string]ExpressionFunction)
+	return NewEvaluableExpressionWithFunctions(expression, functions)
+}
+
+/*
+	Similar to [NewEvaluableExpression], except that instead of a string, an already-tokenized expression is given.
+	This is useful in cases where you may be generating an expression automatically, or using some other parser (e.g., to parse from a query language)
+*/
+func NewEvaluableExpressionFromTokens(tokens []ExpressionToken) (*EvaluableExpression, error) {
+
+	var ret *EvaluableExpression
+	var err error
+
+	ret = new(EvaluableExpression)
+	ret.QueryDateFormat = isoDateFormat
+
+	err = checkBalance(tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkExpressionSyntax(tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.tokens, err = optimizeTokens(tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.evaluationStages, err = planStages(ret.tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.ChecksTypes = true
+	return ret, nil
+}
+
+/*
+	Similar to [NewEvaluableExpression], except enables the use of user-defined functions.
+	Functions passed into this will be available to the expression.
+*/
+func NewEvaluableExpressionWithFunctions(expression string, functions map[string]ExpressionFunction) (*EvaluableExpression, error) {
+
+	var ret *EvaluableExpression
+	var err error
+
+	ret = new(EvaluableExpression)
+	ret.QueryDateFormat = isoDateFormat
+	ret.inputExpression = expression
+
+	ret.tokens, err = parseTokens(expression, functions)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkBalance(ret.tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkExpressionSyntax(ret.tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.tokens, err = optimizeTokens(ret.tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.evaluationStages, err = planStages(ret.tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.ChecksTypes = true
+	return ret, nil
+}
+
+/*
+	Same as `Eval`, but automatically wraps a map of parameters into a `govalute.Parameters` structure.
+*/
+func (this EvaluableExpression) Evaluate(parameters map[string]interface{}) (interface{}, error) {
+
+	if parameters == nil {
+		return this.Eval(nil)
+	}
+	return this.Eval(MapParameters(parameters))
+}
+
+/*
+	Runs the entire expression using the given [parameters].
+	e.g., If the expression contains a reference to the variable "foo", it will be taken from `parameters.Get("foo")`.
+
+	This function returns errors if the combination of expression and parameters cannot be run,
+	such as if a variable in the expression is not present in [parameters].
+
+	In all non-error circumstances, this returns the single value result of the expression and parameters given.
+	e.g., if the expression is "1 + 1", this will return 2.0.
+	e.g., if the expression is "foo + 1" and parameters contains "foo" = 2, this will return 3.0
+*/
+func (this EvaluableExpression) Eval(parameters Parameters) (interface{}, error) {
+
+	if this.evaluationStages == nil {
+		return nil, nil
+	}
+
+	if parameters != nil {
+		parameters = &sanitizedParameters{parameters}
+	}
+	return this.evaluateStage(this.evaluationStages, parameters)
+}
+
+func (this EvaluableExpression) evaluateStage(stage *evaluationStage, parameters Parameters) (interface{}, error) {
+
+	var left, right interface{}
+	var err error
+
+	if stage.leftStage != nil {
+		left, err = this.evaluateStage(stage.leftStage, parameters)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if stage.isShortCircuitable() {
+		switch stage.symbol {
+			case AND:
+				if left == false {
+					return false, nil
+				}
+			case OR:
+				if left == true {
+					return true, nil
+				}
+			case COALESCE:
+				if left != nil {
+					return left, nil
+				}
+			
+			case TERNARY_TRUE:
+				if left == false {
+					right = shortCircuitHolder
+				}
+			case TERNARY_FALSE:
+				if left != nil {
+					right = shortCircuitHolder
+				}
+		}
+	}
+
+	if right != shortCircuitHolder && stage.rightStage != nil {
+		right, err = this.evaluateStage(stage.rightStage, parameters)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if this.ChecksTypes {
+		if stage.typeCheck == nil {
+
+			err = typeCheck(stage.leftTypeCheck, left, stage.symbol, stage.typeErrorFormat)
+			if err != nil {
+				return nil, err
+			}
+
+			err = typeCheck(stage.rightTypeCheck, right, stage.symbol, stage.typeErrorFormat)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			// special case where the type check needs to know both sides to determine if the operator can handle it
+			if !stage.typeCheck(left, right) {
+				errorMsg := fmt.Sprintf(stage.typeErrorFormat, left, stage.symbol.String())
+				return nil, errors.New(errorMsg)
+			}
+		}
+	}
+
+	return stage.operator(left, right, parameters)
+}
+
+func typeCheck(check stageTypeCheck, value interface{}, symbol OperatorSymbol, format string) error {
+
+	if check == nil {
+		return nil
+	}
+
+	if check(value) {
+		return nil
+	}
+
+	errorMsg := fmt.Sprintf(format, value, symbol.String())
+	return errors.New(errorMsg)
+}
+
+/*
+	Returns an array representing the ExpressionTokens that make up this expression.
+*/
+func (this EvaluableExpression) Tokens() []ExpressionToken {
+
+	return this.tokens
+}
+
+/*
+	Returns the original expression used to create this EvaluableExpression.
+*/
+func (this EvaluableExpression) String() string {
+
+	return this.inputExpression
+}
+
+/*
+	Returns an array representing the variables contained in this EvaluableExpression.
+*/
+func (this EvaluableExpression) Vars() []string {
+	var varlist []string
+	for _, val := range this.Tokens() {
+		if val.Kind == VARIABLE {
+			varlist = append(varlist, val.Value.(string))
+		}
+	}
+	return varlist
+}

--- a/vendor/github.com/Knetic/govaluate/EvaluableExpression_sql.go
+++ b/vendor/github.com/Knetic/govaluate/EvaluableExpression_sql.go
@@ -1,0 +1,167 @@
+package govaluate
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+/*
+	Returns a string representing this expression as if it were written in SQL.
+	This function assumes that all parameters exist within the same table, and that the table essentially represents
+	a serialized object of some sort (e.g., hibernate).
+	If your data model is more normalized, you may need to consider iterating through each actual token given by `Tokens()`
+	to create your query.
+
+	Boolean values are considered to be "1" for true, "0" for false.
+
+	Times are formatted according to this.QueryDateFormat.
+*/
+func (this EvaluableExpression) ToSQLQuery() (string, error) {
+
+	var stream *tokenStream
+	var transactions *expressionOutputStream
+	var transaction string
+	var err error
+
+	stream = newTokenStream(this.tokens)
+	transactions = new(expressionOutputStream)
+
+	for stream.hasNext() {
+
+		transaction, err = this.findNextSQLString(stream, transactions)
+		if err != nil {
+			return "", err
+		}
+
+		transactions.add(transaction)
+	}
+
+	return transactions.createString(" "), nil
+}
+
+func (this EvaluableExpression) findNextSQLString(stream *tokenStream, transactions *expressionOutputStream) (string, error) {
+
+	var token ExpressionToken
+	var ret string
+
+	token = stream.next()
+
+	switch token.Kind {
+
+	case STRING:
+		ret = fmt.Sprintf("'%v'", token.Value)
+	case PATTERN:
+		ret = fmt.Sprintf("'%s'", token.Value.(*regexp.Regexp).String())
+	case TIME:
+		ret = fmt.Sprintf("'%s'", token.Value.(time.Time).Format(this.QueryDateFormat))
+
+	case LOGICALOP:
+		switch logicalSymbols[token.Value.(string)] {
+
+		case AND:
+			ret = "AND"
+		case OR:
+			ret = "OR"
+		}
+
+	case BOOLEAN:
+		if token.Value.(bool) {
+			ret = "1"
+		} else {
+			ret = "0"
+		}
+
+	case VARIABLE:
+		ret = fmt.Sprintf("[%s]", token.Value.(string))
+
+	case NUMERIC:
+		ret = fmt.Sprintf("%g", token.Value.(float64))
+
+	case COMPARATOR:
+		switch comparatorSymbols[token.Value.(string)] {
+
+		case EQ:
+			ret = "="
+		case NEQ:
+			ret = "<>"
+		case REQ:
+			ret = "RLIKE"
+		case NREQ:
+			ret = "NOT RLIKE"
+		default:
+			ret = fmt.Sprintf("%s", token.Value.(string))
+		}
+
+	case TERNARY:
+
+		switch ternarySymbols[token.Value.(string)] {
+
+		case COALESCE:
+
+			left := transactions.rollback()
+			right, err := this.findNextSQLString(stream, transactions)
+			if err != nil {
+				return "", err
+			}
+
+			ret = fmt.Sprintf("COALESCE(%v, %v)", left, right)
+		case TERNARY_TRUE:
+			fallthrough
+		case TERNARY_FALSE:
+			return "", errors.New("Ternary operators are unsupported in SQL output")
+		}
+	case PREFIX:
+		switch prefixSymbols[token.Value.(string)] {
+
+		case INVERT:
+			ret = fmt.Sprintf("NOT")
+		default:
+
+			right, err := this.findNextSQLString(stream, transactions)
+			if err != nil {
+				return "", err
+			}
+
+			ret = fmt.Sprintf("%s%s", token.Value.(string), right)
+		}
+	case MODIFIER:
+
+		switch modifierSymbols[token.Value.(string)] {
+
+		case EXPONENT:
+
+			left := transactions.rollback()
+			right, err := this.findNextSQLString(stream, transactions)
+			if err != nil {
+				return "", err
+			}
+
+			ret = fmt.Sprintf("POW(%s, %s)", left, right)
+		case MODULUS:
+
+			left := transactions.rollback()
+			right, err := this.findNextSQLString(stream, transactions)
+			if err != nil {
+				return "", err
+			}
+
+			ret = fmt.Sprintf("MOD(%s, %s)", left, right)
+		default:
+			ret = fmt.Sprintf("%s", token.Value.(string))
+		}
+	case CLAUSE:
+		ret = "("
+	case CLAUSE_CLOSE:
+		ret = ")"
+	case SEPARATOR:
+		ret = ","
+
+	default:
+		errorMsg := fmt.Sprintf("Unrecognized query token '%s' of kind '%s'", token.Value, token.Kind)
+		return "", errors.New(errorMsg)
+	}
+
+	return ret, nil
+}

--- a/vendor/github.com/Knetic/govaluate/ExpressionToken.go
+++ b/vendor/github.com/Knetic/govaluate/ExpressionToken.go
@@ -1,0 +1,9 @@
+package govaluate
+
+/*
+	Represents a single parsed token.
+*/
+type ExpressionToken struct {
+	Kind  TokenKind
+	Value interface{}
+}

--- a/vendor/github.com/Knetic/govaluate/LICENSE
+++ b/vendor/github.com/Knetic/govaluate/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2016 George Lester
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/Knetic/govaluate/MANUAL.md
+++ b/vendor/github.com/Knetic/govaluate/MANUAL.md
@@ -1,0 +1,176 @@
+govaluate
+====
+
+This library contains quite a lot of functionality, this document is meant to be formal documentation on the operators and features of it.
+Some of this documentation may duplicate what's in README.md, but should never conflict.
+
+# Types
+
+This library only officially deals with four types; `float64`, `bool`, `string`, and arrays.
+
+All numeric literals, with or without a radix, will be converted to `float64` for evaluation. For instance; in practice, there is no difference between the literals "1.0" and "1", they both end up as `float64`. This matters to users because if you intend to return numeric values from your expressions, then the returned value will be `float64`, not any other numeric type.
+
+Any string _literal_ (not parameter) which is interpretable as a date will be converted to a `float64` representation of that date's unix time. Any `time.Time` parameters will not be operable with these date literals; such parameters will need to use the `time.Time.Unix()` method to get a numeric representation.
+
+Arrays are untyped, and can be mixed-type. Internally they're all just `interface{}`. Only two operators can interact with arrays, `IN` and `,`. All other operators will refuse to operate on arrays.
+
+# Operators
+
+## Modifiers
+
+### Addition, concatenation `+`
+
+If either left or right sides of the `+` operator are a `string`, then this operator will perform string concatenation and return that result. If neither are string, then both must be numeric, and this will return a numeric result.
+
+Any other case is invalid.
+
+### Arithmetic `-` `*` `/` `**` `%`
+
+`**` refers to "take to the power of". For instance, `3 ** 4` == 81.
+
+* _Left side_: numeric
+* _Right side_: numeric
+* _Returns_: numeric
+
+### Bitwise shifts, masks `>>` `<<` `|` `&` `^`
+
+All of these operators convert their `float64` left and right sides to `int64`, perform their operation, and then convert back.
+Given how this library assumes numeric are represented (as `float64`), it is unlikely that this behavior will change, even though it may cause havoc with extremely large or small numbers.
+
+* _Left side_: numeric
+* _Right side_: numeric
+* _Returns_: numeric
+
+### Negation `-`
+
+Prefix only. This can never have a left-hand value.
+
+* _Right side_: numeric
+* _Returns_: numeric
+
+### Inversion `!`
+
+Prefix only. This can never have a left-hand value.
+
+* _Right side_: bool
+* _Returns_: bool
+
+### Bitwise NOT `~`
+
+Prefix only. This can never have a left-hand value.
+
+* _Right side_: numeric
+* _Returns_: numeric
+
+## Logical Operators
+
+For all logical operators, this library will short-circuit the operation if the left-hand side is sufficient to determine what to do. For instance, `true || expensiveOperation()` will not actually call `expensiveOperation()`, since it knows the left-hand side is `true`.
+
+### Logical AND/OR `&&` `||`
+
+* _Left side_: bool
+* _Right side_: bool
+* _Returns_: bool
+
+### Ternary true `?`
+
+Checks if the left side is `true`. If so, returns the right side. If the left side is `false`, returns `nil`.
+In practice, this is commonly used with the other ternary operator.
+
+* _Left side_: bool
+* _Right side_: Any type.
+* _Returns_: Right side or `nil`
+
+### Ternary false `:`
+
+Checks if the left side is `nil`. If so, returns the right side. If the left side is non-nil, returns the left side.
+In practice, this is commonly used with the other ternary operator.
+
+* _Left side_: Any type.
+* _Right side_: Any type.
+* _Returns_: Right side or `nil`
+
+### Null coalescence `??`
+
+Similar to the C# operator. If the left value is non-nil, it returns that. If not, then the right-value is returned.
+
+* _Left side_: Any type.
+* _Right side_: Any type.
+* _Returns_: No specific type - whichever is passed to it.
+
+## Comparators
+
+### Numeric/lexicographic comparators `>` `<` `>=` `<=`
+
+If both sides are numeric, this returns the usual greater/lesser behavior that would be expected.
+If both sides are string, this returns the lexicographic comparison of the strings. This uses Go's standard lexicographic compare.
+
+* _Accepts_: Left and right side must either be both string, or both numeric.
+* _Returns_: bool
+
+### Regex comparators `=~` `!~`
+
+These use go's standard `regexp` flavor of regex. The left side is expected to be the candidate string, the right side is the pattern. `=~` returns whether or not the candidate string matches the regex pattern given on the right. `!~` is the inverted version of the same logic.
+
+* _Left side_: string
+* _Right side_: string
+* _Returns_: bool
+
+## Arrays
+
+### Separator `,`
+
+The separator, always paired with parenthesis, creates arrays. It must always have both a left and right-hand value, so for instance `(, 0)` and `(0,)` are invalid uses of it.
+
+Again, this should always be used with parenthesis; like `(1, 2, 3, 4)`.
+
+### Membership `IN`
+
+The only operator with a text name, this operator checks the right-hand side array to see if it contains a value that is equal to the left-side value.
+Equality is determined by the use of the `==` operator, and this library doesn't check types between the values. Any two values, when cast to `interface{}`, and can still be checked for equality with `==` will act as expected.
+
+Note that you can use a parameter for the array, but it must be an `[]interface{}`.
+
+* _Left side_: Any type.
+* _Right side_: array
+* _Returns_: bool
+
+# Parameters
+
+Parameters must be passed in every time the expression is evaluated. Parameters can be of any type, but will not cause errors unless actually used in an erroneous way. There is no difference in behavior for any of the above operators for parameters - they are type checked when used.
+
+All `int` and `float` values of any width will be converted to `float64` before use.
+
+At no point is the parameter structure, or any value thereof, modified by this library.
+
+## Alternates to maps
+
+The default form of parameters as a map may not serve your use case. You may have parameters in some other structure, you may want to change the no-parameter-found behavior, or maybe even just have some debugging print statements invoked when a parameter is accessed.
+
+To do this, define a type that implements the `govaluate.Parameters` interface. When you want to evaluate, instead call `EvaluableExpression.Eval` and pass your parameter structure.
+
+# Functions
+
+During expression parsing (_not_ evaluation), a map of functions can be given to `govaluate.NewEvaluableExpressionWithFunctions` (the lengthiest and finest of function names). The resultant expression will be able to invoke those functions during evaluation. Once parsed, an expression cannot have functions added or removed - a new expression will need to be created if you want to change the functions, or behavior of said functions.
+
+Functions always take the form `<name>(<parameters>)`, including parens. Functions can have an empty list of parameters, like `<name>()`, but still must have parens.
+
+If the expression contains something that looks like it ought to be a function (such as `foo()`), but no such function was given to it, it will error on parsing.
+
+Functions must be of type `map[string]govaluate.ExpressionFunction`. `ExpressionFunction`, for brevity, has the following signature:
+
+`func(args ...interface{}) (interface{}, error)`
+
+Where `args` is whatever is passed to the function when called. If a non-nil error is returned from a function during evaluation, the evaluation stops and ultimately returns that error to the caller of `Evaluate()` or `Eval()`.
+
+## Built-in functions
+
+There aren't any builtin functions. The author is opposed to maintaining a standard library of functions to be used.
+
+Every use case of this library is different, and even in simple use cases (such as parameters, see above) different users need different behavior, naming, or even functionality. The author prefers that users make their own decisions about what functions they need, and how they operate.
+
+# Equality
+
+The `==` and `!=` operators involve a moderately complex workflow. They use [`reflect.DeepEqual`](https://golang.org/pkg/reflect/#DeepEqual). This is for complicated reasons, but there are some types in Go that cannot be compared with the native `==` operator. Arrays, in particular, cannot be compared - Go will panic if you try. One might assume this could be handled with the type checking system in `govaluate`, but unfortunately without reflection there is no way to know if a variable is a slice/array. Worse, structs can be incomparable if they _contain incomparable types_.
+
+It's all very complicated. Fortunately, Go includes the `reflect.DeepEqual` function to handle all the edge cases. Currently, `govaluate` uses that for all equality/inequality.

--- a/vendor/github.com/Knetic/govaluate/OperatorSymbol.go
+++ b/vendor/github.com/Knetic/govaluate/OperatorSymbol.go
@@ -1,0 +1,306 @@
+package govaluate
+
+/*
+	Represents the valid symbols for operators.
+
+*/
+type OperatorSymbol int
+
+const (
+	VALUE OperatorSymbol = iota
+	LITERAL
+	NOOP
+	EQ
+	NEQ
+	GT
+	LT
+	GTE
+	LTE
+	REQ
+	NREQ
+	IN
+
+	AND
+	OR
+
+	PLUS
+	MINUS
+	BITWISE_AND
+	BITWISE_OR
+	BITWISE_XOR
+	BITWISE_LSHIFT
+	BITWISE_RSHIFT
+	MULTIPLY
+	DIVIDE
+	MODULUS
+	EXPONENT
+
+	NEGATE
+	INVERT
+	BITWISE_NOT
+
+	TERNARY_TRUE
+	TERNARY_FALSE
+	COALESCE
+
+	FUNCTIONAL
+	SEPARATE
+)
+
+type operatorPrecedence int
+
+const (
+	noopPrecedence operatorPrecedence = iota
+	valuePrecedence
+	functionalPrecedence
+	prefixPrecedence
+	exponentialPrecedence
+	additivePrecedence
+	bitwisePrecedence
+	bitwiseShiftPrecedence
+	multiplicativePrecedence
+	comparatorPrecedence
+	ternaryPrecedence
+	logicalAndPrecedence
+	logicalOrPrecedence
+	separatePrecedence
+)
+
+func findOperatorPrecedenceForSymbol(symbol OperatorSymbol) operatorPrecedence {
+
+	switch symbol {
+	case NOOP:
+		return noopPrecedence
+	case VALUE:
+		return valuePrecedence
+	case EQ:
+		fallthrough
+	case NEQ:
+		fallthrough
+	case GT:
+		fallthrough
+	case LT:
+		fallthrough
+	case GTE:
+		fallthrough
+	case LTE:
+		fallthrough
+	case REQ:
+		fallthrough
+	case NREQ:
+		fallthrough
+	case IN:
+		return comparatorPrecedence
+	case AND:
+		return logicalAndPrecedence
+	case OR:
+		return logicalOrPrecedence
+	case BITWISE_AND:
+		fallthrough
+	case BITWISE_OR:
+		fallthrough
+	case BITWISE_XOR:
+		return bitwisePrecedence
+	case BITWISE_LSHIFT:
+		fallthrough
+	case BITWISE_RSHIFT:
+		return bitwiseShiftPrecedence
+	case PLUS:
+		fallthrough
+	case MINUS:
+		return additivePrecedence
+	case MULTIPLY:
+		fallthrough
+	case DIVIDE:
+		fallthrough
+	case MODULUS:
+		return multiplicativePrecedence
+	case EXPONENT:
+		return exponentialPrecedence
+	case BITWISE_NOT:
+		fallthrough
+	case NEGATE:
+		fallthrough
+	case INVERT:
+		return prefixPrecedence
+	case COALESCE:
+		fallthrough
+	case TERNARY_TRUE:
+		fallthrough
+	case TERNARY_FALSE:
+		return ternaryPrecedence
+	case FUNCTIONAL:
+		return functionalPrecedence
+	case SEPARATE:
+		return separatePrecedence
+	}
+
+	return valuePrecedence
+}
+
+/*
+	Map of all valid comparators, and their string equivalents.
+	Used during parsing of expressions to determine if a symbol is, in fact, a comparator.
+	Also used during evaluation to determine exactly which comparator is being used.
+*/
+var comparatorSymbols = map[string]OperatorSymbol{
+	"==": EQ,
+	"!=": NEQ,
+	">":  GT,
+	">=": GTE,
+	"<":  LT,
+	"<=": LTE,
+	"=~": REQ,
+	"!~": NREQ,
+	"in": IN,
+}
+
+var logicalSymbols = map[string]OperatorSymbol{
+	"&&": AND,
+	"||": OR,
+}
+
+var bitwiseSymbols = map[string]OperatorSymbol{
+	"^": BITWISE_XOR,
+	"&": BITWISE_AND,
+	"|": BITWISE_OR,
+}
+
+var bitwiseShiftSymbols = map[string]OperatorSymbol{
+	">>": BITWISE_RSHIFT,
+	"<<": BITWISE_LSHIFT,
+}
+
+var additiveSymbols = map[string]OperatorSymbol{
+	"+": PLUS,
+	"-": MINUS,
+}
+
+var multiplicativeSymbols = map[string]OperatorSymbol{
+	"*": MULTIPLY,
+	"/": DIVIDE,
+	"%": MODULUS,
+}
+
+var exponentialSymbolsS = map[string]OperatorSymbol{
+	"**": EXPONENT,
+}
+
+var prefixSymbols = map[string]OperatorSymbol{
+	"-": NEGATE,
+	"!": INVERT,
+	"~": BITWISE_NOT,
+}
+
+var ternarySymbols = map[string]OperatorSymbol{
+	"?":  TERNARY_TRUE,
+	":":  TERNARY_FALSE,
+	"??": COALESCE,
+}
+
+// this is defined separately from additiveSymbols et al because it's needed for parsing, not stage planning.
+var modifierSymbols = map[string]OperatorSymbol{
+	"+":  PLUS,
+	"-":  MINUS,
+	"*":  MULTIPLY,
+	"/":  DIVIDE,
+	"%":  MODULUS,
+	"**": EXPONENT,
+	"&":  BITWISE_AND,
+	"|":  BITWISE_OR,
+	"^":  BITWISE_XOR,
+	">>": BITWISE_RSHIFT,
+	"<<": BITWISE_LSHIFT,
+}
+
+var separatorSymbols = map[string]OperatorSymbol{
+	",": SEPARATE,
+}
+
+/*
+	Returns true if this operator is contained by the given array of candidate symbols.
+	False otherwise.
+*/
+func (this OperatorSymbol) IsModifierType(candidate []OperatorSymbol) bool {
+
+	for _, symbolType := range candidate {
+		if this == symbolType {
+			return true
+		}
+	}
+
+	return false
+}
+
+/*
+	Generally used when formatting type check errors.
+	We could store the stringified symbol somewhere else and not require a duplicated codeblock to translate
+	OperatorSymbol to string, but that would require more memory, and another field somewhere.
+	Adding operators is rare enough that we just stringify it here instead.
+*/
+func (this OperatorSymbol) String() string {
+
+	switch this {
+	case NOOP:
+		return "NOOP"
+	case VALUE:
+		return "VALUE"
+	case EQ:
+		return "="
+	case NEQ:
+		return "!="
+	case GT:
+		return ">"
+	case LT:
+		return "<"
+	case GTE:
+		return ">="
+	case LTE:
+		return "<="
+	case REQ:
+		return "=~"
+	case NREQ:
+		return "!~"
+	case AND:
+		return "&&"
+	case OR:
+		return "||"
+	case IN:
+		return "in"
+	case BITWISE_AND:
+		return "&"
+	case BITWISE_OR:
+		return "|"
+	case BITWISE_XOR:
+		return "^"
+	case BITWISE_LSHIFT:
+		return "<<"
+	case BITWISE_RSHIFT:
+		return ">>"
+	case PLUS:
+		return "+"
+	case MINUS:
+		return "-"
+	case MULTIPLY:
+		return "*"
+	case DIVIDE:
+		return "/"
+	case MODULUS:
+		return "%"
+	case EXPONENT:
+		return "**"
+	case NEGATE:
+		return "-"
+	case INVERT:
+		return "!"
+	case BITWISE_NOT:
+		return "~"
+	case TERNARY_TRUE:
+		return "?"
+	case TERNARY_FALSE:
+		return ":"
+	case COALESCE:
+		return "??"
+	}
+	return ""
+}

--- a/vendor/github.com/Knetic/govaluate/README.md
+++ b/vendor/github.com/Knetic/govaluate/README.md
@@ -1,0 +1,210 @@
+govaluate
+====
+
+[![Build Status](https://travis-ci.org/Knetic/govaluate.svg?branch=master)](https://travis-ci.org/Knetic/govaluate)
+[![Godoc](https://godoc.org/github.com/Knetic/govaluate?status.png)](https://godoc.org/github.com/Knetic/govaluate)
+
+
+Provides support for evaluating arbitrary C-like artithmetic/string expressions.
+
+Why can't you just write these expressions in code?
+--
+
+Sometimes, you can't know ahead-of-time what an expression will look like, or you want those expressions to be configurable.
+Perhaps you've got a set of data running through your application, and you want to allow your users to specify some validations to run on it before committing it to a database. Or maybe you've written a monitoring framework which is capable of gathering a bunch of metrics, then evaluating a few expressions to see if any metrics should be alerted upon, but the conditions for alerting are different for each monitor.
+
+A lot of people wind up writing their own half-baked style of evaluation language that fits their needs, but isn't complete. Or they wind up baking the expression into the actual executable, even if they know it's subject to change. These strategies may work, but they take time to implement, time for users to learn, and induce technical debt as requirements change. This library is meant to cover all the normal C-like expressions, so that you don't have to reinvent one of the oldest wheels on a computer.
+
+How do I use it?
+--
+
+You create a new EvaluableExpression, then call "Evaluate" on it.
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("10 > 0");
+	result, err := expression.Evaluate(nil);
+	// result is now set to "true", the bool value.
+```
+
+Cool, but how about with parameters?
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("foo > 0");
+
+	parameters := make(map[string]interface{}, 8)
+	parameters["foo"] = -1;
+
+	result, err := expression.Evaluate(parameters);
+	// result is now set to "false", the bool value.
+```
+
+That's cool, but we can almost certainly have done all that in code. What about a complex use case that involves some math?
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("(requests_made * requests_succeeded / 100) >= 90");
+
+	parameters := make(map[string]interface{}, 8)
+	parameters["requests_made"] = 100;
+	parameters["requests_succeeded"] = 80;
+
+	result, err := expression.Evaluate(parameters);
+	// result is now set to "false", the bool value.
+```
+
+Or maybe you want to check the status of an alive check ("smoketest") page, which will be a string?
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("http_response_body == 'service is ok'");
+
+	parameters := make(map[string]interface{}, 8)
+	parameters["http_response_body"] = "service is ok";
+
+	result, err := expression.Evaluate(parameters);
+	// result is now set to "true", the bool value.
+```
+
+These examples have all returned boolean values, but it's equally possible to return numeric ones.
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("(mem_used / total_mem) * 100");
+
+	parameters := make(map[string]interface{}, 8)
+	parameters["total_mem"] = 1024;
+	parameters["mem_used"] = 512;
+
+	result, err := expression.Evaluate(parameters);
+	// result is now set to "50.0", the float64 value.
+```
+
+You can also do date parsing, though the formats are somewhat limited. Stick to RF3339, ISO8061, unix date, or ruby date formats. If you're having trouble getting a date string to parse, check the list of formats actually used: [parsing.go:248](https://github.com/Knetic/govaluate/blob/0580e9b47a69125afa0e4ebd1cf93c49eb5a43ec/parsing.go#L258).
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("'2014-01-02' > '2014-01-01 23:59:59'");
+	result, err := expression.Evaluate(nil);
+
+	// result is now set to true
+```
+
+Expressions are parsed once, and can be re-used multiple times. Parsing is the compute-intensive phase of the process, so if you intend to use the same expression with different parameters, just parse it once. Like so;
+
+```go
+	expression, err := govaluate.NewEvaluableExpression("response_time <= 100");
+	parameters := make(map[string]interface{}, 8)
+
+	for {
+		parameters["response_time"] = pingSomething();
+		result, err := expression.Evaluate(parameters)
+	}
+```
+
+The normal C-standard order of operators is respected. When writing an expression, be sure that you either order the operators correctly, or use parenthesis to clarify which portions of an expression should be run first.
+
+Escaping characters
+--
+
+Sometimes you'll have parameters that have spaces, slashes, pluses, ampersands or some other character
+that this library interprets as something special. For example, the following expression will not
+act as one might expect:
+
+	"response-time < 100"
+
+As written, the library will parse it as "[response] minus [time] is less than 100". In reality,
+"response-time" is meant to be one variable that just happens to have a dash in it.
+
+There are two ways to work around this. First, you can escape the entire parameter name:
+
+ 	"[response-time] < 100"
+
+Or you can use backslashes to escape only the minus sign.
+
+	"response\\-time < 100"
+
+Backslashes can be used anywhere in an expression to escape the very next character. Square bracketed parameter names can be used instead of plain parameter names at any time.
+
+Functions
+--
+
+You may have cases where you want to call a function on a parameter during execution of the expression. Perhaps you want to aggregate some set of data, but don't know the exact aggregation you want to use until you're writing the expression itself. Or maybe you have a mathematical operation you want to perform, for which there is no operator; like `log` or `tan` or `sqrt`. For cases like this, you can provide a map of functions to `NewEvaluableExpressionWithFunctions`, which will then be able to use them during execution. For instance;
+
+```go
+	functions := map[string]govaluate.ExpressionFunction {
+		"strlen": func(args ...interface{}) (interface{}, error) {
+			length := len(args[0].(string))
+			return (float64)(length), nil
+		},
+	}
+
+	expString := "strlen('someReallyLongInputString') <= 16"
+	expression, _ := govaluate.NewEvaluableExpressionWithFunctions(expString, functions)
+
+	result, _ := expression.Evaluate(nil)
+	// result is now "false", the boolean value
+```
+
+Functions can accept any number of arguments, correctly handles nested functions, and arguments can be of any type (even if none of this library's operators support evaluation of that type). For instance, each of these usages of functions in an expression are valid (assuming that the appropriate functions and parameters are given):
+
+```go
+"sqrt(x1 ** y1, x2 ** y2)"
+"max(someValue, abs(anotherValue), 10 * lastValue)"
+```
+
+Functions cannot be passed as parameters, they must be known at the time when the expression is parsed, and are unchangeable after parsing.
+
+What operators and types does this support?
+--
+
+* Modifiers: `+` `-` `/` `*` `&` `|` `^` `**` `%` `>>` `<<`
+* Comparators: `>` `>=` `<` `<=` `==` `!=` `=~` `!~`
+* Logical ops: `||` `&&`
+* Numeric constants, as 64-bit floating point (`12345.678`)
+* String constants (single quotes: `'foobar'`)
+* Date constants (single quotes, using any permutation of RFC3339, ISO8601, ruby date, or unix date; date parsing is automatically tried with any string constant)
+* Boolean constants: `true` `false`
+* Parenthesis to control order of evaluation `(` `)`
+* Arrays (anything separated by `,` within parenthesis: `(1, 2, 'foo')`)
+* Prefixes: `!` `-` `~`
+* Ternary conditional: `?` `:`
+* Null coalescence: `??`
+
+See [MANUAL.md](https://github.com/Knetic/govaluate/blob/master/MANUAL.md) for exacting details on what types each operator supports.
+
+Types
+--
+
+Some operators don't make sense when used with some types. For instance, what does it mean to get the modulo of a string? What happens if you check to see if two numbers are logically AND'ed together?
+
+Everyone has a different intuition about the answers to these questions. To prevent confusion, this library will _refuse to operate_ upon types for which there is not an unambiguous meaning for the operation. See [MANUAL.md](https://github.com/Knetic/govaluate/blob/master/MANUAL.md) for details about what operators are valid for which types.
+
+Benchmarks
+--
+
+If you're concerned about the overhead of this library, a good range of benchmarks are built into this repo. You can run them with `go test -bench=.`. The library is built with an eye towards being quick, but has not been aggressively profiled and optimized. For most applications, though, it is completely fine.
+
+For a very rough idea of performance, here are the results output from a benchmark run on a 3rd-gen Macbook Pro (Linux Mint 17.1).
+
+```
+BenchmarkSingleParse-12                          1000000              1382 ns/op
+BenchmarkSimpleParse-12                           200000             10771 ns/op
+BenchmarkFullParse-12                              30000             49383 ns/op
+BenchmarkEvaluationSingle-12                    50000000                30.1 ns/op
+BenchmarkEvaluationNumericLiteral-12            10000000               119 ns/op
+BenchmarkEvaluationLiteralModifiers-12          10000000               236 ns/op
+BenchmarkEvaluationParameters-12                 5000000               260 ns/op
+BenchmarkEvaluationParametersModifiers-12        3000000               547 ns/op
+BenchmarkComplexExpression-12                    2000000               963 ns/op
+BenchmarkRegexExpression-12                       100000             20357 ns/op
+BenchmarkConstantRegexExpression-12              1000000              1392 ns/op
+ok
+```
+
+API Breaks
+--
+
+While this library has very few cases which will ever result in an API break, it can (and [has](https://github.com/Knetic/govaluate/releases/tag/2.0.0)) happened. If you are using this in production, vendor the commit you've tested against, or use gopkg.in to redirect your import (e.g., `import "gopkg.in/Knetic/govaluate.v2"`). Master branch (while infrequent) _may_ at some point contain API breaking changes, and the author will have no way to communicate these to downstreams, other than creating a new major release.
+
+Releases will explicitly state when an API break happens, and if they do not specify an API break it should be safe to upgrade.
+
+License
+--
+
+This project is licensed under the MIT general use license. You're free to integrate, fork, and play with this code as you feel fit without consulting the author, as long as you provide proper credit to the author in your works.

--- a/vendor/github.com/Knetic/govaluate/TokenKind.go
+++ b/vendor/github.com/Knetic/govaluate/TokenKind.go
@@ -1,0 +1,72 @@
+package govaluate
+
+/*
+	Represents all valid types of tokens that a token can be.
+*/
+type TokenKind int
+
+const (
+	UNKNOWN TokenKind = iota
+
+	PREFIX
+	NUMERIC
+	BOOLEAN
+	STRING
+	PATTERN
+	TIME
+	VARIABLE
+	FUNCTION
+	SEPARATOR
+
+	COMPARATOR
+	LOGICALOP
+	MODIFIER
+
+	CLAUSE
+	CLAUSE_CLOSE
+
+	TERNARY
+)
+
+/*
+	GetTokenKindString returns a string that describes the given TokenKind.
+	e.g., when passed the NUMERIC TokenKind, this returns the string "NUMERIC".
+*/
+func (kind TokenKind) String() string {
+
+	switch kind {
+
+	case PREFIX:
+		return "PREFIX"
+	case NUMERIC:
+		return "NUMERIC"
+	case BOOLEAN:
+		return "BOOLEAN"
+	case STRING:
+		return "STRING"
+	case PATTERN:
+		return "PATTERN"
+	case TIME:
+		return "TIME"
+	case VARIABLE:
+		return "VARIABLE"
+	case FUNCTION:
+		return "FUNCTION"
+	case SEPARATOR:
+		return "SEPARATOR"
+	case COMPARATOR:
+		return "COMPARATOR"
+	case LOGICALOP:
+		return "LOGICALOP"
+	case MODIFIER:
+		return "MODIFIER"
+	case CLAUSE:
+		return "CLAUSE"
+	case CLAUSE_CLOSE:
+		return "CLAUSE_CLOSE"
+	case TERNARY:
+		return "TERNARY"
+	}
+
+	return "UNKNOWN"
+}

--- a/vendor/github.com/Knetic/govaluate/evaluationStage.go
+++ b/vendor/github.com/Knetic/govaluate/evaluationStage.go
@@ -1,0 +1,359 @@
+package govaluate
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"reflect"
+)
+
+const (
+	logicalErrorFormat    string = "Value '%v' cannot be used with the logical operator '%v', it is not a bool"
+	modifierErrorFormat   string = "Value '%v' cannot be used with the modifier '%v', it is not a number"
+	comparatorErrorFormat string = "Value '%v' cannot be used with the comparator '%v', it is not a number"
+	ternaryErrorFormat    string = "Value '%v' cannot be used with the ternary operator '%v', it is not a bool"
+	prefixErrorFormat     string = "Value '%v' cannot be used with the prefix '%v'"
+)
+
+type evaluationOperator func(left interface{}, right interface{}, parameters Parameters) (interface{}, error)
+type stageTypeCheck func(value interface{}) bool
+type stageCombinedTypeCheck func(left interface{}, right interface{}) bool
+
+type evaluationStage struct {
+	symbol OperatorSymbol
+
+	leftStage, rightStage *evaluationStage
+
+	// the operation that will be used to evaluate this stage (such as adding [left] to [right] and return the result)
+	operator evaluationOperator
+
+	// ensures that both left and right values are appropriate for this stage. Returns an error if they aren't operable.
+	leftTypeCheck  stageTypeCheck
+	rightTypeCheck stageTypeCheck
+
+	// if specified, will override whatever is used in "leftTypeCheck" and "rightTypeCheck".
+	// primarily used for specific operators that don't care which side a given type is on, but still requires one side to be of a given type
+	// (like string concat)
+	typeCheck stageCombinedTypeCheck
+
+	// regardless of which type check is used, this string format will be used as the error message for type errors
+	typeErrorFormat string
+}
+
+var (
+	_true  = interface{}(true)
+	_false = interface{}(false)
+)
+
+func (this *evaluationStage) swapWith(other *evaluationStage) {
+
+	temp := *other
+	other.setToNonStage(*this)
+	this.setToNonStage(temp)
+}
+
+func (this *evaluationStage) setToNonStage(other evaluationStage) {
+
+	this.symbol = other.symbol
+	this.operator = other.operator
+	this.leftTypeCheck = other.leftTypeCheck
+	this.rightTypeCheck = other.rightTypeCheck
+	this.typeCheck = other.typeCheck
+	this.typeErrorFormat = other.typeErrorFormat
+}
+
+func (this *evaluationStage) isShortCircuitable() bool {
+
+	switch this.symbol {
+		case AND:
+			fallthrough
+		case OR:
+			fallthrough
+		case TERNARY_TRUE: 
+			fallthrough
+		case TERNARY_FALSE:
+			fallthrough
+		case COALESCE:
+			return true
+	}
+
+	return false
+}
+
+func noopStageRight(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return right, nil
+}
+
+func addStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+
+	// string concat if either are strings
+	if isString(left) || isString(right) {
+		return fmt.Sprintf("%v%v", left, right), nil
+	}
+
+	return left.(float64) + right.(float64), nil
+}
+func subtractStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return left.(float64) - right.(float64), nil
+}
+func multiplyStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return left.(float64) * right.(float64), nil
+}
+func divideStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return left.(float64) / right.(float64), nil
+}
+func exponentStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return math.Pow(left.(float64), right.(float64)), nil
+}
+func modulusStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return math.Mod(left.(float64), right.(float64)), nil
+}
+func gteStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) >= right.(string)), nil
+	}
+	return boolIface(left.(float64) >= right.(float64)), nil
+}
+func gtStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) > right.(string)), nil
+	}
+	return boolIface(left.(float64) > right.(float64)), nil
+}
+func lteStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) <= right.(string)), nil
+	}
+	return boolIface(left.(float64) <= right.(float64)), nil
+}
+func ltStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	if isString(left) && isString(right) {
+		return boolIface(left.(string) < right.(string)), nil
+	}
+	return boolIface(left.(float64) < right.(float64)), nil
+}
+func equalStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return boolIface(reflect.DeepEqual(left, right)), nil
+}
+func notEqualStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return boolIface(!reflect.DeepEqual(left, right)), nil
+}
+func andStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return boolIface(left.(bool) && right.(bool)), nil
+}
+func orStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return boolIface(left.(bool) || right.(bool)), nil
+}
+func negateStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return -right.(float64), nil
+}
+func invertStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return boolIface(!right.(bool)), nil
+}
+func bitwiseNotStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return float64(^int64(right.(float64))), nil
+}
+func ternaryIfStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	if left.(bool) {
+		return right, nil
+	}
+	return nil, nil
+}
+func ternaryElseStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	if left != nil {
+		return left, nil
+	}
+	return right, nil
+}
+
+func regexStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+
+	var pattern *regexp.Regexp
+	var err error
+
+	switch right.(type) {
+	case string:
+		pattern, err = regexp.Compile(right.(string))
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Unable to compile regexp pattern '%v': %v", right, err))
+		}
+	case *regexp.Regexp:
+		pattern = right.(*regexp.Regexp)
+	}
+
+	return pattern.Match([]byte(left.(string))), nil
+}
+
+func notRegexStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+
+	ret, err := regexStage(left, right, parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	return !(ret.(bool)), nil
+}
+
+func bitwiseOrStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return float64(int64(left.(float64)) | int64(right.(float64))), nil
+}
+func bitwiseAndStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return float64(int64(left.(float64)) & int64(right.(float64))), nil
+}
+func bitwiseXORStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return float64(int64(left.(float64)) ^ int64(right.(float64))), nil
+}
+func leftShiftStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return float64(uint64(left.(float64)) << uint64(right.(float64))), nil
+}
+func rightShiftStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+	return float64(uint64(left.(float64)) >> uint64(right.(float64))), nil
+}
+
+func makeParameterStage(parameterName string) evaluationOperator {
+
+	return func(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+		value, err := parameters.Get(parameterName)
+		if err != nil {
+			return nil, err
+		}
+
+		return value, nil
+	}
+}
+
+func makeLiteralStage(literal interface{}) evaluationOperator {
+	return func(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+		return literal, nil
+	}
+}
+
+func makeFunctionStage(function ExpressionFunction) evaluationOperator {
+
+	return func(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+
+		if right == nil {
+			return function()
+		}
+
+		switch right.(type) {
+		case []interface{}:
+			return function(right.([]interface{})...)
+		default:
+			return function(right)
+		}
+
+	}
+}
+
+func separatorStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+
+	var ret []interface{}
+
+	switch left.(type) {
+	case []interface{}:
+		ret = append(left.([]interface{}), right)
+	default:
+		ret = []interface{}{left, right}
+	}
+
+	return ret, nil
+}
+
+func inStage(left interface{}, right interface{}, parameters Parameters) (interface{}, error) {
+
+	for _, value := range right.([]interface{}) {
+		if left == value {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+//
+
+func isString(value interface{}) bool {
+
+	switch value.(type) {
+	case string:
+		return true
+	}
+	return false
+}
+
+func isRegexOrString(value interface{}) bool {
+
+	switch value.(type) {
+	case string:
+		return true
+	case *regexp.Regexp:
+		return true
+	}
+	return false
+}
+
+func isBool(value interface{}) bool {
+	switch value.(type) {
+	case bool:
+		return true
+	}
+	return false
+}
+
+func isFloat64(value interface{}) bool {
+	switch value.(type) {
+	case float64:
+		return true
+	}
+	return false
+}
+
+/*
+	Addition usually means between numbers, but can also mean string concat.
+	String concat needs one (or both) of the sides to be a string.
+*/
+func additionTypeCheck(left interface{}, right interface{}) bool {
+
+	if isFloat64(left) && isFloat64(right) {
+		return true
+	}
+	if !isString(left) && !isString(right) {
+		return false
+	}
+	return true
+}
+
+/*
+	Comparison can either be between numbers, or lexicographic between two strings,
+	but never between the two.
+*/
+func comparatorTypeCheck(left interface{}, right interface{}) bool {
+
+	if isFloat64(left) && isFloat64(right) {
+		return true
+	}
+	if isString(left) && isString(right) {
+		return true
+	}
+	return false
+}
+
+func isArray(value interface{}) bool {
+	switch value.(type) {
+	case []interface{}:
+		return true
+	}
+	return false
+}
+
+/*
+	Converting a boolean to an interface{} requires an allocation.
+	We can use interned bools to avoid this cost.
+*/
+func boolIface(b bool) interface{} {
+	if b {
+		return _true
+	}
+	return _false
+}

--- a/vendor/github.com/Knetic/govaluate/expressionFunctions.go
+++ b/vendor/github.com/Knetic/govaluate/expressionFunctions.go
@@ -1,0 +1,8 @@
+package govaluate
+
+/*
+	Represents a function that can be called from within an expression.
+	This method must return an error if, for any reason, it is unable to produce exactly one unambiguous result.
+	An error returned will halt execution of the expression.
+*/
+type ExpressionFunction func(arguments ...interface{}) (interface{}, error)

--- a/vendor/github.com/Knetic/govaluate/expressionOutputStream.go
+++ b/vendor/github.com/Knetic/govaluate/expressionOutputStream.go
@@ -1,0 +1,46 @@
+package govaluate
+
+import (
+	"bytes"
+)
+
+/*
+	Holds a series of "transactions" which represent each token as it is output by an outputter (such as ToSQLQuery()).
+	Some outputs (such as SQL) require a function call or non-c-like syntax to represent an expression.
+	To accomplish this, this struct keeps track of each translated token as it is output, and can return and rollback those transactions.
+*/
+type expressionOutputStream struct {
+	transactions []string
+}
+
+func (this *expressionOutputStream) add(transaction string) {
+	this.transactions = append(this.transactions, transaction)
+}
+
+func (this *expressionOutputStream) rollback() string {
+
+	index := len(this.transactions) - 1
+	ret := this.transactions[index]
+
+	this.transactions = this.transactions[:index]
+	return ret
+}
+
+func (this *expressionOutputStream) createString(delimiter string) string {
+
+	var retBuffer bytes.Buffer
+	var transaction string
+
+	penultimate := len(this.transactions) - 1
+
+	for i := 0; i < penultimate; i++ {
+
+		transaction = this.transactions[i]
+
+		retBuffer.WriteString(transaction)
+		retBuffer.WriteString(delimiter)
+	}
+	retBuffer.WriteString(this.transactions[penultimate])
+
+	return retBuffer.String()
+}

--- a/vendor/github.com/Knetic/govaluate/lexerState.go
+++ b/vendor/github.com/Knetic/govaluate/lexerState.go
@@ -1,0 +1,350 @@
+package govaluate
+
+import (
+	"errors"
+	"fmt"
+)
+
+type lexerState struct {
+	isEOF          bool
+	isNullable     bool
+	kind           TokenKind
+	validNextKinds []TokenKind
+}
+
+// lexer states.
+// Constant for all purposes except compiler.
+var validLexerStates = []lexerState{
+
+	lexerState{
+		kind: UNKNOWN,
+		isEOF: false,
+		isNullable: true,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			BOOLEAN,
+			VARIABLE,
+			PATTERN,
+			FUNCTION,
+			STRING,
+			TIME,
+			CLAUSE,
+		},
+	},
+
+	lexerState{
+
+		kind:       CLAUSE,
+		isEOF:      false,
+		isNullable: true,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			BOOLEAN,
+			VARIABLE,
+			PATTERN,
+			FUNCTION,
+			STRING,
+			TIME,
+			CLAUSE,
+			CLAUSE_CLOSE,
+		},
+	},
+
+	lexerState{
+
+		kind:       CLAUSE_CLOSE,
+		isEOF:      true,
+		isNullable: true,
+		validNextKinds: []TokenKind{
+
+			COMPARATOR,
+			MODIFIER,
+			NUMERIC,
+			BOOLEAN,
+			VARIABLE,
+			STRING,
+			PATTERN,
+			TIME,
+			CLAUSE,
+			CLAUSE_CLOSE,
+			LOGICALOP,
+			TERNARY,
+			SEPARATOR,
+		},
+	},
+
+	lexerState{
+
+		kind:       NUMERIC,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			MODIFIER,
+			COMPARATOR,
+			LOGICALOP,
+			CLAUSE_CLOSE,
+			TERNARY,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       BOOLEAN,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			MODIFIER,
+			COMPARATOR,
+			LOGICALOP,
+			CLAUSE_CLOSE,
+			TERNARY,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       STRING,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			MODIFIER,
+			COMPARATOR,
+			LOGICALOP,
+			CLAUSE_CLOSE,
+			TERNARY,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       TIME,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			MODIFIER,
+			COMPARATOR,
+			LOGICALOP,
+			CLAUSE_CLOSE,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       PATTERN,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			MODIFIER,
+			COMPARATOR,
+			LOGICALOP,
+			CLAUSE_CLOSE,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       VARIABLE,
+		isEOF:      true,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			MODIFIER,
+			COMPARATOR,
+			LOGICALOP,
+			CLAUSE_CLOSE,
+			TERNARY,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       MODIFIER,
+		isEOF:      false,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			VARIABLE,
+			FUNCTION,
+			STRING,
+			BOOLEAN,
+			CLAUSE,
+			CLAUSE_CLOSE,
+		},
+	},
+	lexerState{
+
+		kind:       COMPARATOR,
+		isEOF:      false,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			BOOLEAN,
+			VARIABLE,
+			FUNCTION,
+			STRING,
+			TIME,
+			CLAUSE,
+			CLAUSE_CLOSE,
+			PATTERN,
+		},
+	},
+	lexerState{
+
+		kind:       LOGICALOP,
+		isEOF:      false,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			BOOLEAN,
+			VARIABLE,
+			FUNCTION,
+			STRING,
+			TIME,
+			CLAUSE,
+			CLAUSE_CLOSE,
+		},
+	},
+	lexerState{
+
+		kind:       PREFIX,
+		isEOF:      false,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			NUMERIC,
+			BOOLEAN,
+			VARIABLE,
+			FUNCTION,
+			CLAUSE,
+			CLAUSE_CLOSE,
+		},
+	},
+
+	lexerState{
+
+		kind:       TERNARY,
+		isEOF:      false,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			BOOLEAN,
+			STRING,
+			TIME,
+			VARIABLE,
+			FUNCTION,
+			CLAUSE,
+			SEPARATOR,
+		},
+	},
+	lexerState{
+
+		kind:       FUNCTION,
+		isEOF:      false,
+		isNullable: false,
+		validNextKinds: []TokenKind{
+			CLAUSE,
+		},
+	},
+	lexerState{
+
+		kind:       SEPARATOR,
+		isEOF:      false,
+		isNullable: true,
+		validNextKinds: []TokenKind{
+
+			PREFIX,
+			NUMERIC,
+			BOOLEAN,
+			STRING,
+			TIME,
+			VARIABLE,
+			FUNCTION,
+			CLAUSE,
+		},
+	},
+}
+
+func (this lexerState) canTransitionTo(kind TokenKind) bool {
+
+	for _, validKind := range this.validNextKinds {
+
+		if validKind == kind {
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkExpressionSyntax(tokens []ExpressionToken) error {
+
+	var state lexerState
+	var lastToken ExpressionToken
+	var err error
+
+	state = validLexerStates[0]
+
+	for _, token := range tokens {
+
+		if !state.canTransitionTo(token.Kind) {
+
+			// call out a specific error for tokens looking like they want to be functions.
+			if lastToken.Kind == VARIABLE && token.Kind == CLAUSE {
+				return errors.New("Undefined function " + lastToken.Value.(string))
+			}
+
+			firstStateName := fmt.Sprintf("%s [%v]", state.kind.String(), lastToken.Value)
+			nextStateName := fmt.Sprintf("%s [%v]", token.Kind.String(), token.Value)
+
+			return errors.New("Cannot transition token types from " + firstStateName + " to " + nextStateName)
+		}
+
+		state, err = getLexerStateForToken(token.Kind)
+		if err != nil {
+			return err
+		}
+
+		if !state.isNullable && token.Value == nil {
+
+			errorMsg := fmt.Sprintf("Token kind '%v' cannot have a nil value", token.Kind.String())
+			return errors.New(errorMsg)
+		}
+
+		lastToken = token
+	}
+
+	if !state.isEOF {
+		return errors.New("Unexpected end of expression")
+	}
+	return nil
+}
+
+func getLexerStateForToken(kind TokenKind) (lexerState, error) {
+
+	for _, possibleState := range validLexerStates {
+
+		if possibleState.kind == kind {
+			return possibleState, nil
+		}
+	}
+
+	errorMsg := fmt.Sprintf("No lexer state found for token kind '%v'\n", kind.String())
+	return validLexerStates[0], errors.New(errorMsg)
+}

--- a/vendor/github.com/Knetic/govaluate/lexerStream.go
+++ b/vendor/github.com/Knetic/govaluate/lexerStream.go
@@ -1,0 +1,39 @@
+package govaluate
+
+type lexerStream struct {
+	source   []rune
+	position int
+	length   int
+}
+
+func newLexerStream(source string) *lexerStream {
+
+	var ret *lexerStream
+	var runes []rune
+
+	for _, character := range source {
+		runes = append(runes, character)
+	}
+
+	ret = new(lexerStream)
+	ret.source = runes
+	ret.length = len(runes)
+	return ret
+}
+
+func (this *lexerStream) readCharacter() rune {
+
+	var character rune
+
+	character = this.source[this.position]
+	this.position += 1
+	return character
+}
+
+func (this *lexerStream) rewind(amount int) {
+	this.position -= amount
+}
+
+func (this lexerStream) canRead() bool {
+	return this.position < this.length
+}

--- a/vendor/github.com/Knetic/govaluate/parameters.go
+++ b/vendor/github.com/Knetic/govaluate/parameters.go
@@ -1,0 +1,32 @@
+package govaluate
+
+import (
+	"errors"
+)
+
+/*
+	Parameters is a collection of named parameters that can be used by an EvaluableExpression to retrieve parameters
+	when an expression tries to use them.
+*/
+type Parameters interface {
+
+	/*
+		Get gets the parameter of the given name, or an error if the parameter is unavailable.
+		Failure to find the given parameter should be indicated by returning an error.
+	*/
+	Get(name string) (interface{}, error)
+}
+
+type MapParameters map[string]interface{}
+
+func (p MapParameters) Get(name string) (interface{}, error) {
+
+	value, found := p[name]
+
+	if !found {
+		errorMessage := "No parameter '" + name + "' found."
+		return nil, errors.New(errorMessage)
+	}
+
+	return value, nil
+}

--- a/vendor/github.com/Knetic/govaluate/parsing.go
+++ b/vendor/github.com/Knetic/govaluate/parsing.go
@@ -1,0 +1,450 @@
+package govaluate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+	"unicode"
+)
+
+func parseTokens(expression string, functions map[string]ExpressionFunction) ([]ExpressionToken, error) {
+
+	var ret []ExpressionToken
+	var token ExpressionToken
+	var stream *lexerStream
+	var state lexerState
+	var err error
+	var found bool
+
+	stream = newLexerStream(expression)
+	state = validLexerStates[0]
+
+	for stream.canRead() {
+
+		token, err, found = readToken(stream, state, functions)
+
+		if err != nil {
+			return ret, err
+		}
+
+		if !found {
+			break
+		}
+
+		state, err = getLexerStateForToken(token.Kind)
+		if err != nil {
+			return ret, err
+		}
+
+		// append this valid token
+		ret = append(ret, token)
+	}
+
+	err = checkBalance(ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func readToken(stream *lexerStream, state lexerState, functions map[string]ExpressionFunction) (ExpressionToken, error, bool) {
+
+	var function ExpressionFunction
+	var ret ExpressionToken
+	var tokenValue interface{}
+	var tokenTime time.Time
+	var tokenString string
+	var kind TokenKind
+	var character rune
+	var found bool
+	var completed bool
+	var err error
+
+	// numeric is 0-9, or .
+	// string starts with '
+	// variable is alphanumeric, always starts with a letter
+	// bracket always means variable
+	// symbols are anything non-alphanumeric
+	// all others read into a buffer until they reach the end of the stream
+	for stream.canRead() {
+
+		character = stream.readCharacter()
+
+		if unicode.IsSpace(character) {
+			continue
+		}
+
+		kind = UNKNOWN
+
+		// numeric constant
+		if isNumeric(character) {
+
+			tokenString = readTokenUntilFalse(stream, isNumeric)
+			tokenValue, err = strconv.ParseFloat(tokenString, 64)
+
+			if err != nil {
+				errorMsg := fmt.Sprintf("Unable to parse numeric value '%v' to float64\n", tokenString)
+				return ExpressionToken{}, errors.New(errorMsg), false
+			}
+			kind = NUMERIC
+			break
+		}
+
+		// comma, separator
+		if character == ',' {
+
+			tokenValue = ","
+			kind = SEPARATOR
+			break
+		}
+
+		// escaped variable
+		if character == '[' {
+
+			tokenValue, completed = readUntilFalse(stream, true, false, true, isNotClosingBracket)
+			kind = VARIABLE
+
+			if !completed {
+				return ExpressionToken{}, errors.New("Unclosed parameter bracket"), false
+			}
+
+			// above method normally rewinds us to the closing bracket, which we want to skip.
+			stream.rewind(-1)
+			break
+		}
+
+		// regular variable - or function?
+		if unicode.IsLetter(character) {
+
+			tokenString = readTokenUntilFalse(stream, isVariableName)
+
+			tokenValue = tokenString
+			kind = VARIABLE
+
+			// boolean?
+			if tokenValue == "true" {
+
+				kind = BOOLEAN
+				tokenValue = true
+			} else {
+
+				if tokenValue == "false" {
+
+					kind = BOOLEAN
+					tokenValue = false
+				}
+			}
+
+			// textual operator?
+			if tokenValue == "in" || tokenValue == "IN" {
+
+				// force lower case for consistency
+				tokenValue = "in"
+				kind = COMPARATOR
+			}
+
+			// function?
+			function, found = functions[tokenString]
+			if found {
+				kind = FUNCTION
+				tokenValue = function
+			}
+			break
+		}
+
+		if !isNotQuote(character) {
+			tokenValue, completed = readUntilFalse(stream, true, false, true, isNotQuote)
+
+			if !completed {
+				return ExpressionToken{}, errors.New("Unclosed string literal"), false
+			}
+
+			// advance the stream one position, since reading until false assumes the terminator is a real token
+			stream.rewind(-1)
+
+			// check to see if this can be parsed as a time.
+			tokenTime, found = tryParseTime(tokenValue.(string))
+			if found {
+				kind = TIME
+				tokenValue = tokenTime
+			} else {
+				kind = STRING
+			}
+			break
+		}
+
+		if character == '(' {
+			tokenValue = character
+			kind = CLAUSE
+			break
+		}
+
+		if character == ')' {
+			tokenValue = character
+			kind = CLAUSE_CLOSE
+			break
+		}
+
+		// must be a known symbol
+		tokenString = readTokenUntilFalse(stream, isNotAlphanumeric)
+		tokenValue = tokenString
+
+		// quick hack for the case where "-" can mean "prefixed negation" or "minus", which are used
+		// very differently.
+		if state.canTransitionTo(PREFIX) {
+			_, found = prefixSymbols[tokenString]
+			if found {
+
+				kind = PREFIX
+				break
+			}
+		}
+		_, found = modifierSymbols[tokenString]
+		if found {
+
+			kind = MODIFIER
+			break
+		}
+
+		_, found = logicalSymbols[tokenString]
+		if found {
+
+			kind = LOGICALOP
+			break
+		}
+
+		_, found = comparatorSymbols[tokenString]
+		if found {
+
+			kind = COMPARATOR
+			break
+		}
+
+		_, found = ternarySymbols[tokenString]
+		if found {
+
+			kind = TERNARY
+			break
+		}
+
+		errorMessage := fmt.Sprintf("Invalid token: '%s'", tokenString)
+		return ret, errors.New(errorMessage), false
+	}
+
+	ret.Kind = kind
+	ret.Value = tokenValue
+
+	return ret, nil, (kind != UNKNOWN)
+}
+
+func readTokenUntilFalse(stream *lexerStream, condition func(rune) bool) string {
+
+	var ret string
+
+	stream.rewind(1)
+	ret, _ = readUntilFalse(stream, false, true, true, condition)
+	return ret
+}
+
+/*
+	Returns the string that was read until the given [condition] was false, or whitespace was broken.
+	Returns false if the stream ended before whitespace was broken or condition was met.
+*/
+func readUntilFalse(stream *lexerStream, includeWhitespace bool, breakWhitespace bool, allowEscaping bool, condition func(rune) bool) (string, bool) {
+
+	var tokenBuffer bytes.Buffer
+	var character rune
+	var conditioned bool
+
+	conditioned = false
+
+	for stream.canRead() {
+
+		character = stream.readCharacter()
+
+		// Use backslashes to escape anything
+		if allowEscaping && character == '\\' {
+
+			character = stream.readCharacter()
+			tokenBuffer.WriteString(string(character))
+			continue
+		}
+
+		if unicode.IsSpace(character) {
+
+			if breakWhitespace && tokenBuffer.Len() > 0 {
+				conditioned = true
+				break
+			}
+			if !includeWhitespace {
+				continue
+			}
+		}
+
+		if condition(character) {
+			tokenBuffer.WriteString(string(character))
+		} else {
+			conditioned = true
+			stream.rewind(1)
+			break
+		}
+	}
+
+	return tokenBuffer.String(), conditioned
+}
+
+/*
+	Checks to see if any optimizations can be performed on the given [tokens], which form a complete, valid expression.
+	The returns slice will represent the optimized (or unmodified) list of tokens to use.
+*/
+func optimizeTokens(tokens []ExpressionToken) ([]ExpressionToken, error) {
+
+	var token ExpressionToken
+	var symbol OperatorSymbol
+	var err error
+	var index int
+
+	for index, token = range tokens {
+
+		// if we find a regex operator, and the right-hand value is a constant, precompile and replace with a pattern.
+		if token.Kind != COMPARATOR {
+			continue
+		}
+
+		symbol = comparatorSymbols[token.Value.(string)]
+		if symbol != REQ && symbol != NREQ {
+			continue
+		}
+
+		index++
+		token = tokens[index]
+		if token.Kind == STRING {
+
+			token.Kind = PATTERN
+			token.Value, err = regexp.Compile(token.Value.(string))
+
+			if err != nil {
+				return tokens, err
+			}
+
+			tokens[index] = token
+		}
+	}
+	return tokens, nil
+}
+
+/*
+	Checks the balance of tokens which have multiple parts, such as parenthesis.
+*/
+func checkBalance(tokens []ExpressionToken) error {
+
+	var stream *tokenStream
+	var token ExpressionToken
+	var parens int
+
+	stream = newTokenStream(tokens)
+
+	for stream.hasNext() {
+
+		token = stream.next()
+		if token.Kind == CLAUSE {
+			parens++
+			continue
+		}
+		if token.Kind == CLAUSE_CLOSE {
+			parens--
+			continue
+		}
+	}
+
+	if parens != 0 {
+		return errors.New("Unbalanced parenthesis")
+	}
+	return nil
+}
+
+func isNumeric(character rune) bool {
+
+	return unicode.IsDigit(character) || character == '.'
+}
+
+func isNotQuote(character rune) bool {
+
+	return character != '\'' && character != '"'
+}
+
+func isNotAlphanumeric(character rune) bool {
+
+	return !(unicode.IsDigit(character) ||
+		unicode.IsLetter(character) ||
+		character == '(' ||
+		character == ')' ||
+		!isNotQuote(character))
+}
+
+func isVariableName(character rune) bool {
+
+	return unicode.IsLetter(character) ||
+		unicode.IsDigit(character) ||
+		character == '_'
+}
+
+func isNotClosingBracket(character rune) bool {
+
+	return character != ']'
+}
+
+/*
+	Attempts to parse the [candidate] as a Time.
+	Tries a series of standardized date formats, returns the Time if one applies,
+	otherwise returns false through the second return.
+*/
+func tryParseTime(candidate string) (time.Time, bool) {
+
+	var ret time.Time
+	var found bool
+
+	timeFormats := [...]string{
+		time.ANSIC,
+		time.UnixDate,
+		time.RubyDate,
+		time.Kitchen,
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02",                         // RFC 3339
+		"2006-01-02 15:04",                   // RFC 3339 with minutes
+		"2006-01-02 15:04:05",                // RFC 3339 with seconds
+		"2006-01-02 15:04:05-07:00",          // RFC 3339 with seconds and timezone
+		"2006-01-02T15Z0700",                 // ISO8601 with hour
+		"2006-01-02T15:04Z0700",              // ISO8601 with minutes
+		"2006-01-02T15:04:05Z0700",           // ISO8601 with seconds
+		"2006-01-02T15:04:05.999999999Z0700", // ISO8601 with nanoseconds
+	}
+
+	for _, format := range timeFormats {
+
+		ret, found = tryParseExactTime(candidate, format)
+		if found {
+			return ret, true
+		}
+	}
+
+	return time.Now(), false
+}
+
+func tryParseExactTime(candidate string, format string) (time.Time, bool) {
+
+	var ret time.Time
+	var err error
+
+	ret, err = time.ParseInLocation(format, candidate, time.Local)
+	if err != nil {
+		return time.Now(), false
+	}
+
+	return ret, true
+}

--- a/vendor/github.com/Knetic/govaluate/sanitizedParameters.go
+++ b/vendor/github.com/Knetic/govaluate/sanitizedParameters.go
@@ -1,0 +1,71 @@
+package govaluate
+
+// sanitizedParameters is a wrapper for Parameters that does sanitization as
+// parameters are accessed.
+type sanitizedParameters struct {
+	orig Parameters
+}
+
+func (p sanitizedParameters) Get(key string) (interface{}, error) {
+	value, err := p.orig.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// should be converted to fixed point?
+	if isFixedPoint(value) {
+		return castFixedPoint(value), nil
+	}
+
+	return value, nil
+}
+
+func isFixedPoint(value interface{}) bool {
+
+	switch value.(type) {
+	case uint8:
+		return true
+	case uint16:
+		return true
+	case uint32:
+		return true
+	case uint64:
+		return true
+	case int8:
+		return true
+	case int16:
+		return true
+	case int32:
+		return true
+	case int64:
+		return true
+	case int:
+		return true
+	}
+	return false
+}
+
+func castFixedPoint(value interface{}) float64 {
+	switch value.(type) {
+	case uint8:
+		return float64(value.(uint8))
+	case uint16:
+		return float64(value.(uint16))
+	case uint32:
+		return float64(value.(uint32))
+	case uint64:
+		return float64(value.(uint64))
+	case int8:
+		return float64(value.(int8))
+	case int16:
+		return float64(value.(int16))
+	case int32:
+		return float64(value.(int32))
+	case int64:
+		return float64(value.(int64))
+	case int:
+		return float64(value.(int))
+	}
+
+	return 0.0
+}

--- a/vendor/github.com/Knetic/govaluate/stagePlanner.go
+++ b/vendor/github.com/Knetic/govaluate/stagePlanner.go
@@ -1,0 +1,675 @@
+package govaluate
+
+import (
+	"errors"
+	"time"
+	"fmt"
+)
+
+var stageSymbolMap = map[OperatorSymbol]evaluationOperator{
+	EQ:             equalStage,
+	NEQ:            notEqualStage,
+	GT:             gtStage,
+	LT:             ltStage,
+	GTE:            gteStage,
+	LTE:            lteStage,
+	REQ:            regexStage,
+	NREQ:           notRegexStage,
+	AND:            andStage,
+	OR:             orStage,
+	IN:             inStage,
+	BITWISE_OR:     bitwiseOrStage,
+	BITWISE_AND:    bitwiseAndStage,
+	BITWISE_XOR:    bitwiseXORStage,
+	BITWISE_LSHIFT: leftShiftStage,
+	BITWISE_RSHIFT: rightShiftStage,
+	PLUS:           addStage,
+	MINUS:          subtractStage,
+	MULTIPLY:       multiplyStage,
+	DIVIDE:         divideStage,
+	MODULUS:        modulusStage,
+	EXPONENT:       exponentStage,
+	NEGATE:         negateStage,
+	INVERT:         invertStage,
+	BITWISE_NOT:    bitwiseNotStage,
+	TERNARY_TRUE:   ternaryIfStage,
+	TERNARY_FALSE:  ternaryElseStage,
+	COALESCE:       ternaryElseStage,
+	SEPARATE:       separatorStage,
+}
+
+/*
+	A "precedent" is a function which will recursively parse new evaluateionStages from a given stream of tokens.
+	It's called a `precedent` because it is expected to handle exactly what precedence of operator,
+	and defer to other `precedent`s for other operators.
+*/
+type precedent func(stream *tokenStream) (*evaluationStage, error)
+
+/*
+	A convenience function for specifying the behavior of a `precedent`.
+	Most `precedent` functions can be described by the same function, just with different type checks, symbols, and error formats.
+	This struct is passed to `makePrecedentFromPlanner` to create a `precedent` function.
+*/
+type precedencePlanner struct {
+	validSymbols map[string]OperatorSymbol
+	validKinds   []TokenKind
+
+	typeErrorFormat string
+
+	next      precedent
+	nextRight precedent
+}
+
+var planPrefix precedent
+var planExponential precedent
+var planMultiplicative precedent
+var planAdditive precedent
+var planBitwise precedent
+var planShift precedent
+var planComparator precedent
+var planLogicalAnd precedent
+var planLogicalOr precedent
+var planTernary precedent
+var planSeparator precedent
+
+func init() {
+
+	// all these stages can use the same code (in `planPrecedenceLevel`) to execute,
+	// they simply need different type checks, symbols, and recursive precedents.
+	// While not all precedent phases are listed here, most can be represented this way.
+	planPrefix = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    prefixSymbols,
+		validKinds:      []TokenKind{PREFIX},
+		typeErrorFormat: prefixErrorFormat,
+		nextRight:       planFunction,
+	})
+	planExponential = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    exponentialSymbolsS,
+		validKinds:      []TokenKind{MODIFIER},
+		typeErrorFormat: modifierErrorFormat,
+		next:            planFunction,
+	})
+	planMultiplicative = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    multiplicativeSymbols,
+		validKinds:      []TokenKind{MODIFIER},
+		typeErrorFormat: modifierErrorFormat,
+		next:            planExponential,
+	})
+	planAdditive = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    additiveSymbols,
+		validKinds:      []TokenKind{MODIFIER},
+		typeErrorFormat: modifierErrorFormat,
+		next:            planMultiplicative,
+	})
+	planShift = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    bitwiseShiftSymbols,
+		validKinds:      []TokenKind{MODIFIER},
+		typeErrorFormat: modifierErrorFormat,
+		next:            planAdditive,
+	})
+	planBitwise = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    bitwiseSymbols,
+		validKinds:      []TokenKind{MODIFIER},
+		typeErrorFormat: modifierErrorFormat,
+		next:            planShift,
+	})
+	planComparator = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    comparatorSymbols,
+		validKinds:      []TokenKind{COMPARATOR},
+		typeErrorFormat: comparatorErrorFormat,
+		next:            planBitwise,
+	})
+	planLogicalAnd = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    map[string]OperatorSymbol{"&&": AND},
+		validKinds:      []TokenKind{LOGICALOP},
+		typeErrorFormat: logicalErrorFormat,
+		next:            planComparator,
+	})
+	planLogicalOr = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    map[string]OperatorSymbol{"||": OR},
+		validKinds:      []TokenKind{LOGICALOP},
+		typeErrorFormat: logicalErrorFormat,
+		next:            planLogicalAnd,
+	})
+	planTernary = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols:    ternarySymbols,
+		validKinds:      []TokenKind{TERNARY},
+		typeErrorFormat: ternaryErrorFormat,
+		next:            planLogicalOr,
+	})
+	planSeparator = makePrecedentFromPlanner(&precedencePlanner{
+		validSymbols: separatorSymbols,
+		validKinds:   []TokenKind{SEPARATOR},
+		next:         planTernary,
+	})
+}
+
+/*
+	Given a planner, creates a function which will evaluate a specific precedence level of operators,
+	and link it to other `precedent`s which recurse to parse other precedence levels.
+*/
+func makePrecedentFromPlanner(planner *precedencePlanner) precedent {
+
+	var generated precedent
+	var nextRight precedent
+
+	generated = func(stream *tokenStream) (*evaluationStage, error) {
+		return planPrecedenceLevel(
+			stream,
+			planner.typeErrorFormat,
+			planner.validSymbols,
+			planner.validKinds,
+			nextRight,
+			planner.next,
+		)
+	}
+
+	if planner.nextRight != nil {
+		nextRight = planner.nextRight
+	} else {
+		nextRight = generated
+	}
+
+	return generated
+}
+
+/*
+	Creates a `evaluationStageList` object which represents an execution plan (or tree)
+	which is used to completely evaluate a set of tokens at evaluation-time.
+	The three stages of evaluation can be thought of as parsing strings to tokens, then tokens to a stage list, then evaluation with parameters.
+*/
+func planStages(tokens []ExpressionToken) (*evaluationStage, error) {
+
+	stream := newTokenStream(tokens)
+
+	stage, err := planTokens(stream)
+	if err != nil {
+		return nil, err
+	}
+
+	// while we're now fully-planned, we now need to re-order same-precedence operators.
+	// this could probably be avoided with a different planning method
+	reorderStages(stage)
+
+	stage = elideLiterals(stage)
+	return stage, nil
+}
+
+func planTokens(stream *tokenStream) (*evaluationStage, error) {
+
+	if !stream.hasNext() {
+		return nil, nil
+	}
+
+	return planSeparator(stream)
+}
+
+/*
+	The most usual method of parsing an evaluation stage for a given precedence.
+	Most stages use the same logic
+*/
+func planPrecedenceLevel(
+	stream *tokenStream,
+	typeErrorFormat string,
+	validSymbols map[string]OperatorSymbol,
+	validKinds []TokenKind,
+	rightPrecedent precedent,
+	leftPrecedent precedent) (*evaluationStage, error) {
+
+	var token ExpressionToken
+	var symbol OperatorSymbol
+	var leftStage, rightStage *evaluationStage
+	var checks typeChecks
+	var err error
+	var keyFound bool
+
+	if leftPrecedent != nil {
+
+		leftStage, err = leftPrecedent(stream)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for stream.hasNext() {
+
+		token = stream.next()
+
+		if len(validKinds) > 0 {
+
+			keyFound = false
+			for _, kind := range validKinds {
+				if kind == token.Kind {
+					keyFound = true
+					break
+				}
+			}
+
+			if !keyFound {
+				break
+			}
+		}
+
+		if validSymbols != nil {
+
+			if !isString(token.Value) {
+				break
+			}
+
+			symbol, keyFound = validSymbols[token.Value.(string)]
+			if !keyFound {
+				break
+			}
+		}
+
+		if rightPrecedent != nil {
+			rightStage, err = rightPrecedent(stream)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		checks = findTypeChecks(symbol)
+
+		return &evaluationStage{
+
+			symbol:     symbol,
+			leftStage:  leftStage,
+			rightStage: rightStage,
+			operator:   stageSymbolMap[symbol],
+
+			leftTypeCheck:   checks.left,
+			rightTypeCheck:  checks.right,
+			typeCheck:       checks.combined,
+			typeErrorFormat: typeErrorFormat,
+		}, nil
+	}
+
+	stream.rewind()
+	return leftStage, nil
+}
+
+/*
+	A special case where functions need to be of higher precedence than values, and need a special wrapped execution stage operator.
+*/
+func planFunction(stream *tokenStream) (*evaluationStage, error) {
+
+	var token ExpressionToken
+	var rightStage *evaluationStage
+	var err error
+
+	token = stream.next()
+
+	if token.Kind != FUNCTION {
+		stream.rewind()
+		return planValue(stream)
+	}
+
+	rightStage, err = planValue(stream)
+	if err != nil {
+		return nil, err
+	}
+
+	return &evaluationStage{
+
+		symbol:          FUNCTIONAL,
+		rightStage:      rightStage,
+		operator:        makeFunctionStage(token.Value.(ExpressionFunction)),
+		typeErrorFormat: "Unable to run function '%v': %v",
+	}, nil
+}
+
+/*
+	A truly special precedence function, this handles all the "lowest-case" errata of the process, including literals, parmeters,
+	clauses, and prefixes.
+*/
+func planValue(stream *tokenStream) (*evaluationStage, error) {
+
+	var token ExpressionToken
+	var symbol OperatorSymbol
+	var ret *evaluationStage
+	var operator evaluationOperator
+	var err error
+
+	token = stream.next()
+
+	switch token.Kind {
+
+	case CLAUSE:
+
+		ret, err = planTokens(stream)
+		if err != nil {
+			return nil, err
+		}
+
+		// advance past the CLAUSE_CLOSE token. We know that it's a CLAUSE_CLOSE, because at parse-time we check for unbalanced parens.
+		stream.next()
+
+		// the stage we got represents all of the logic contained within the parens
+		// but for technical reasons, we need to wrap this stage in a "noop" stage which breaks long chains of precedence.
+		// see github #33.
+		ret = &evaluationStage {
+			rightStage: ret,
+			operator: noopStageRight,
+			symbol: NOOP,
+		}
+
+		return ret, nil
+
+	case CLAUSE_CLOSE:
+
+		// when functions have empty params, this will be hit. In this case, we don't have any evaluation stage to do,
+		// so we just return nil so that the stage planner continues on its way.
+		stream.rewind()
+		return nil, nil
+
+	case VARIABLE:
+		operator = makeParameterStage(token.Value.(string))
+
+	case NUMERIC:
+		fallthrough
+	case STRING:
+		fallthrough
+	case PATTERN:
+		fallthrough
+	case BOOLEAN:
+		symbol = LITERAL
+		operator = makeLiteralStage(token.Value)
+	case TIME:
+		symbol = LITERAL
+		operator = makeLiteralStage(float64(token.Value.(time.Time).Unix()))
+
+	case PREFIX:
+		stream.rewind()
+		return planPrefix(stream)
+	}
+
+	if operator == nil {
+		errorMsg := fmt.Sprintf("Unable to plan token kind: '%s', value: '%v'", token.Kind.String(), token.Value)
+		return nil, errors.New(errorMsg)
+	}
+
+	return &evaluationStage{
+		symbol: symbol,
+		operator: operator,
+	}, nil
+}
+
+/*
+	Convenience function to pass a triplet of typechecks between `findTypeChecks` and `planPrecedenceLevel`.
+	Each of these members may be nil, which indicates that type does not matter for that value.
+*/
+type typeChecks struct {
+	left     stageTypeCheck
+	right    stageTypeCheck
+	combined stageCombinedTypeCheck
+}
+
+/*
+	Maps a given [symbol] to a set of typechecks to be used during runtime.
+*/
+func findTypeChecks(symbol OperatorSymbol) typeChecks {
+
+	switch symbol {
+	case GT:
+		fallthrough
+	case LT:
+		fallthrough
+	case GTE:
+		fallthrough
+	case LTE:
+		return typeChecks{
+			combined: comparatorTypeCheck,
+		}
+	case REQ:
+		fallthrough
+	case NREQ:
+		return typeChecks{
+			left:  isString,
+			right: isRegexOrString,
+		}
+	case AND:
+		fallthrough
+	case OR:
+		return typeChecks{
+			left:  isBool,
+			right: isBool,
+		}
+	case IN:
+		return typeChecks{
+			right: isArray,
+		}
+	case BITWISE_LSHIFT:
+		fallthrough
+	case BITWISE_RSHIFT:
+		fallthrough
+	case BITWISE_OR:
+		fallthrough
+	case BITWISE_AND:
+		fallthrough
+	case BITWISE_XOR:
+		return typeChecks{
+			left:  isFloat64,
+			right: isFloat64,
+		}
+	case PLUS:
+		return typeChecks{
+			combined: additionTypeCheck,
+		}
+	case MINUS:
+		fallthrough
+	case MULTIPLY:
+		fallthrough
+	case DIVIDE:
+		fallthrough
+	case MODULUS:
+		fallthrough
+	case EXPONENT:
+		return typeChecks{
+			left:  isFloat64,
+			right: isFloat64,
+		}
+	case NEGATE:
+		return typeChecks{
+			right: isFloat64,
+		}
+	case INVERT:
+		return typeChecks{
+			right: isBool,
+		}
+	case BITWISE_NOT:
+		return typeChecks{
+			right: isFloat64,
+		}
+	case TERNARY_TRUE:
+		return typeChecks{
+			left: isBool,
+		}
+
+	// unchecked cases
+	case EQ:
+		fallthrough
+	case NEQ:
+		return typeChecks{}
+	case TERNARY_FALSE:
+		fallthrough
+	case COALESCE:
+		fallthrough
+	default:
+		return typeChecks{}
+	}
+}
+
+/*
+	During stage planning, stages of equal precedence are parsed such that they'll be evaluated in reverse order.
+	For commutative operators like "+" or "-", it's no big deal. But for order-specific operators, it ruins the expected result.
+*/
+func reorderStages(rootStage *evaluationStage) {
+
+	// traverse every rightStage until we find multiples in a row of the same precedence.
+	var identicalPrecedences []*evaluationStage
+	var currentStage, nextStage *evaluationStage
+	var precedence, currentPrecedence operatorPrecedence
+
+	nextStage = rootStage
+	precedence = findOperatorPrecedenceForSymbol(rootStage.symbol)
+
+	for nextStage != nil {
+
+		currentStage = nextStage
+		nextStage = currentStage.rightStage
+
+		// left depth first, since this entire method only looks for precedences down the right side of the tree
+		if currentStage.leftStage != nil {
+			reorderStages(currentStage.leftStage)
+		}
+
+		currentPrecedence = findOperatorPrecedenceForSymbol(currentStage.symbol)
+
+		if currentPrecedence == precedence {
+			identicalPrecedences = append(identicalPrecedences, currentStage)
+			continue
+		}
+
+		// precedence break.
+		// See how many in a row we had, and reorder if there's more than one.
+		if len(identicalPrecedences) > 1 {
+			mirrorStageSubtree(identicalPrecedences)
+		}
+
+		identicalPrecedences = []*evaluationStage{currentStage}
+		precedence = currentPrecedence
+	}
+
+	if len(identicalPrecedences) > 1 {
+		mirrorStageSubtree(identicalPrecedences)
+	}
+}
+
+/*
+	Performs a "mirror" on a subtree of stages.
+	This mirror functionally inverts the order of execution for all members of the [stages] list.
+	That list is assumed to be a root-to-leaf (ordered) list of evaluation stages, where each is a right-hand stage of the last.
+*/
+func mirrorStageSubtree(stages []*evaluationStage) {
+
+	var rootStage, inverseStage, carryStage, frontStage *evaluationStage
+
+	stagesLength := len(stages)
+
+	// reverse all right/left
+	for _, frontStage = range stages {
+
+		carryStage = frontStage.rightStage
+		frontStage.rightStage = frontStage.leftStage
+		frontStage.leftStage = carryStage
+	}
+
+	// end left swaps with root right
+	rootStage = stages[0]
+	frontStage = stages[stagesLength-1]
+
+	carryStage = frontStage.leftStage
+	frontStage.leftStage = rootStage.rightStage
+	rootStage.rightStage = carryStage
+
+	// for all non-root non-end stages, right is swapped with inverse stage right in list
+	for i := 0; i < (stagesLength-2)/2+1; i++ {
+
+		frontStage = stages[i+1]
+		inverseStage = stages[stagesLength-i-1]
+
+		carryStage = frontStage.rightStage
+		frontStage.rightStage = inverseStage.rightStage
+		inverseStage.rightStage = carryStage
+	}
+
+	// swap all other information with inverse stages
+	for i := 0; i < stagesLength/2; i++ {
+
+		frontStage = stages[i]
+		inverseStage = stages[stagesLength-i-1]
+		frontStage.swapWith(inverseStage)
+	}
+}
+
+/*
+	Recurses through all operators in the entire tree, eliding operators where both sides are literals.
+*/
+func elideLiterals(root *evaluationStage) *evaluationStage {
+
+	if root.leftStage != nil {
+		root.leftStage = elideLiterals(root.leftStage)
+	}
+
+	if root.rightStage != nil {
+		root.rightStage = elideLiterals(root.rightStage)
+	}
+
+	return elideStage(root)
+}
+
+/*
+	Elides a specific stage, if possible.
+	Returns the unmodified [root] stage if it cannot or should not be elided.
+	Otherwise, returns a new stage representing the condensed value from the elided stages.
+*/
+func elideStage(root *evaluationStage) *evaluationStage {
+
+	var leftValue, rightValue, result interface{}
+	var err error
+
+	// right side must be a non-nil value. Left side must be nil or a value.
+	if root.rightStage == nil ||
+		root.rightStage.symbol != LITERAL ||
+		root.leftStage == nil ||
+		root.leftStage.symbol != LITERAL {
+		return root
+	}
+
+	// don't elide some operators
+	switch root.symbol {
+	case SEPARATE:
+		fallthrough
+	case IN:
+		return root
+	}
+
+	// both sides are values, get their actual values.
+	// errors should be near-impossible here. If we encounter them, just abort this optimization.
+	leftValue, err = root.leftStage.operator(nil, nil, nil)
+	if err != nil {
+		return root
+	}
+
+	rightValue, err = root.rightStage.operator(nil, nil, nil)
+	if err != nil {
+		return root
+	}
+
+	// typcheck, since the grammar checker is a bit loose with which operator symbols go together.
+	err = typeCheck(root.leftTypeCheck, leftValue, root.symbol, root.typeErrorFormat)
+	if err != nil {
+		return root
+	}
+
+	err = typeCheck(root.rightTypeCheck, rightValue, root.symbol, root.typeErrorFormat)
+	if err != nil {
+		return root
+	}
+
+	if root.typeCheck != nil && !root.typeCheck(leftValue, rightValue) {
+		return root
+	}
+
+	// pre-calculate, and return a new stage representing the result.
+	result, err = root.operator(leftValue, rightValue, nil)
+	if err != nil {
+		return root
+	}
+
+	return &evaluationStage {
+		symbol: LITERAL,
+		operator: makeLiteralStage(result),
+	}
+}

--- a/vendor/github.com/Knetic/govaluate/test.sh
+++ b/vendor/github.com/Knetic/govaluate/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Script that runs tests, code coverage, and benchmarks all at once.
+# Builds a symlink in /tmp, mostly to avoid messing with GOPATH at the user's shell level.
+
+TEMPORARY_PATH="/tmp/govaluate_test"
+SRC_PATH="${TEMPORARY_PATH}/src"
+FULL_PATH="${TEMPORARY_PATH}/src/govaluate"
+
+# set up temporary directory
+rm -rf "${FULL_PATH}"
+mkdir -p "${SRC_PATH}"
+
+ln -s $(pwd) "${FULL_PATH}"
+export GOPATH="${TEMPORARY_PATH}"
+
+pushd "${TEMPORARY_PATH}/src/govaluate"
+
+# run the actual tests.
+export GOVALUATE_TORTURE_TEST="true"
+go test -bench=. -benchmem -coverprofile coverage.out
+status=$?
+
+if [ "${status}" != 0 ];
+then
+	exit $status
+fi
+
+# coverage
+go tool cover -func=coverage.out
+
+popd

--- a/vendor/github.com/Knetic/govaluate/tokenStream.go
+++ b/vendor/github.com/Knetic/govaluate/tokenStream.go
@@ -1,0 +1,36 @@
+package govaluate
+
+type tokenStream struct {
+	tokens      []ExpressionToken
+	index       int
+	tokenLength int
+}
+
+func newTokenStream(tokens []ExpressionToken) *tokenStream {
+
+	var ret *tokenStream
+
+	ret = new(tokenStream)
+	ret.tokens = tokens
+	ret.tokenLength = len(tokens)
+	return ret
+}
+
+func (this *tokenStream) rewind() {
+	this.index -= 1
+}
+
+func (this *tokenStream) next() ExpressionToken {
+
+	var token ExpressionToken
+
+	token = this.tokens[this.index]
+
+	this.index += 1
+	return token
+}
+
+func (this tokenStream) hasNext() bool {
+
+	return this.index < this.tokenLength
+}

--- a/vendor/github.com/fatih/structs/.gitignore
+++ b/vendor/github.com/fatih/structs/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/vendor/github.com/fatih/structs/.travis.yml
+++ b/vendor/github.com/fatih/structs/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+go: 
+ - 1.7.x
+ - 1.8.x
+ - 1.9.x
+ - tip
+sudo: false
+before_install:
+- go get github.com/axw/gocov/gocov
+- go get github.com/mattn/goveralls
+- if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+script:
+- $HOME/gopath/bin/goveralls -service=travis-ci

--- a/vendor/github.com/fatih/structs/LICENSE
+++ b/vendor/github.com/fatih/structs/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/fatih/structs/README.md
+++ b/vendor/github.com/fatih/structs/README.md
@@ -1,0 +1,163 @@
+# Structs [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/structs) [![Build Status](http://img.shields.io/travis/fatih/structs.svg?style=flat-square)](https://travis-ci.org/fatih/structs) [![Coverage Status](http://img.shields.io/coveralls/fatih/structs.svg?style=flat-square)](https://coveralls.io/r/fatih/structs)
+
+Structs contains various utilities to work with Go (Golang) structs. It was
+initially used by me to convert a struct into a `map[string]interface{}`. With
+time I've added other utilities for structs.  It's basically a high level
+package based on primitives from the reflect package. Feel free to add new
+functions or improve the existing code.
+
+## Install
+
+```bash
+go get github.com/fatih/structs
+```
+
+## Usage and Examples
+
+Just like the standard lib `strings`, `bytes` and co packages, `structs` has
+many global functions to manipulate or organize your struct data. Lets define
+and declare a struct:
+
+```go
+type Server struct {
+	Name        string `json:"name,omitempty"`
+	ID          int
+	Enabled     bool
+	users       []string // not exported
+	http.Server          // embedded
+}
+
+server := &Server{
+	Name:    "gopher",
+	ID:      123456,
+	Enabled: true,
+}
+```
+
+```go
+// Convert a struct to a map[string]interface{}
+// => {"Name":"gopher", "ID":123456, "Enabled":true}
+m := structs.Map(server)
+
+// Convert the values of a struct to a []interface{}
+// => ["gopher", 123456, true]
+v := structs.Values(server)
+
+// Convert the names of a struct to a []string
+// (see "Names methods" for more info about fields)
+n := structs.Names(server)
+
+// Convert the values of a struct to a []*Field
+// (see "Field methods" for more info about fields)
+f := structs.Fields(server)
+
+// Return the struct name => "Server"
+n := structs.Name(server)
+
+// Check if any field of a struct is initialized or not.
+h := structs.HasZero(server)
+
+// Check if all fields of a struct is initialized or not.
+z := structs.IsZero(server)
+
+// Check if server is a struct or a pointer to struct
+i := structs.IsStruct(server)
+```
+
+### Struct methods
+
+The structs functions can be also used as independent methods by creating a new
+`*structs.Struct`. This is handy if you want to have more control over the
+structs (such as retrieving a single Field).
+
+```go
+// Create a new struct type:
+s := structs.New(server)
+
+m := s.Map()              // Get a map[string]interface{}
+v := s.Values()           // Get a []interface{}
+f := s.Fields()           // Get a []*Field
+n := s.Names()            // Get a []string
+f := s.Field(name)        // Get a *Field based on the given field name
+f, ok := s.FieldOk(name)  // Get a *Field based on the given field name
+n := s.Name()             // Get the struct name
+h := s.HasZero()          // Check if any field is uninitialized
+z := s.IsZero()           // Check if all fields are uninitialized
+```
+
+### Field methods
+
+We can easily examine a single Field for more detail. Below you can see how we
+get and interact with various field methods:
+
+
+```go
+s := structs.New(server)
+
+// Get the Field struct for the "Name" field
+name := s.Field("Name")
+
+// Get the underlying value,  value => "gopher"
+value := name.Value().(string)
+
+// Set the field's value
+name.Set("another gopher")
+
+// Get the field's kind, kind =>  "string"
+name.Kind()
+
+// Check if the field is exported or not
+if name.IsExported() {
+	fmt.Println("Name field is exported")
+}
+
+// Check if the value is a zero value, such as "" for string, 0 for int
+if !name.IsZero() {
+	fmt.Println("Name is initialized")
+}
+
+// Check if the field is an anonymous (embedded) field
+if !name.IsEmbedded() {
+	fmt.Println("Name is not an embedded field")
+}
+
+// Get the Field's tag value for tag name "json", tag value => "name,omitempty"
+tagValue := name.Tag("json")
+```
+
+Nested structs are supported too:
+
+```go
+addrField := s.Field("Server").Field("Addr")
+
+// Get the value for addr
+a := addrField.Value().(string)
+
+// Or get all fields
+httpServer := s.Field("Server").Fields()
+```
+
+We can also get a slice of Fields from the Struct type to iterate over all
+fields. This is handy if you wish to examine all fields:
+
+```go
+s := structs.New(server)
+
+for _, f := range s.Fields() {
+	fmt.Printf("field name: %+v\n", f.Name())
+
+	if f.IsExported() {
+		fmt.Printf("value   : %+v\n", f.Value())
+		fmt.Printf("is zero : %+v\n", f.IsZero())
+	}
+}
+```
+
+## Credits
+
+ * [Fatih Arslan](https://github.com/fatih)
+ * [Cihangir Savas](https://github.com/cihangir)
+
+## License
+
+The MIT License (MIT) - see LICENSE.md for more details

--- a/vendor/github.com/fatih/structs/field.go
+++ b/vendor/github.com/fatih/structs/field.go
@@ -1,0 +1,141 @@
+package structs
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var (
+	errNotExported = errors.New("field is not exported")
+	errNotSettable = errors.New("field is not settable")
+)
+
+// Field represents a single struct field that encapsulates high level
+// functions around the field.
+type Field struct {
+	value      reflect.Value
+	field      reflect.StructField
+	defaultTag string
+}
+
+// Tag returns the value associated with key in the tag string. If there is no
+// such key in the tag, Tag returns the empty string.
+func (f *Field) Tag(key string) string {
+	return f.field.Tag.Get(key)
+}
+
+// Value returns the underlying value of the field. It panics if the field
+// is not exported.
+func (f *Field) Value() interface{} {
+	return f.value.Interface()
+}
+
+// IsEmbedded returns true if the given field is an anonymous field (embedded)
+func (f *Field) IsEmbedded() bool {
+	return f.field.Anonymous
+}
+
+// IsExported returns true if the given field is exported.
+func (f *Field) IsExported() bool {
+	return f.field.PkgPath == ""
+}
+
+// IsZero returns true if the given field is not initialized (has a zero value).
+// It panics if the field is not exported.
+func (f *Field) IsZero() bool {
+	zero := reflect.Zero(f.value.Type()).Interface()
+	current := f.Value()
+
+	return reflect.DeepEqual(current, zero)
+}
+
+// Name returns the name of the given field
+func (f *Field) Name() string {
+	return f.field.Name
+}
+
+// Kind returns the fields kind, such as "string", "map", "bool", etc ..
+func (f *Field) Kind() reflect.Kind {
+	return f.value.Kind()
+}
+
+// Set sets the field to given value v. It returns an error if the field is not
+// settable (not addressable or not exported) or if the given value's type
+// doesn't match the fields type.
+func (f *Field) Set(val interface{}) error {
+	// we can't set unexported fields, so be sure this field is exported
+	if !f.IsExported() {
+		return errNotExported
+	}
+
+	// do we get here? not sure...
+	if !f.value.CanSet() {
+		return errNotSettable
+	}
+
+	given := reflect.ValueOf(val)
+
+	if f.value.Kind() != given.Kind() {
+		return fmt.Errorf("wrong kind. got: %s want: %s", given.Kind(), f.value.Kind())
+	}
+
+	f.value.Set(given)
+	return nil
+}
+
+// Zero sets the field to its zero value. It returns an error if the field is not
+// settable (not addressable or not exported).
+func (f *Field) Zero() error {
+	zero := reflect.Zero(f.value.Type()).Interface()
+	return f.Set(zero)
+}
+
+// Fields returns a slice of Fields. This is particular handy to get the fields
+// of a nested struct . A struct tag with the content of "-" ignores the
+// checking of that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field *http.Request `structs:"-"`
+//
+// It panics if field is not exported or if field's kind is not struct
+func (f *Field) Fields() []*Field {
+	return getFields(f.value, f.defaultTag)
+}
+
+// Field returns the field from a nested struct. It panics if the nested struct
+// is not exported or if the field was not found.
+func (f *Field) Field(name string) *Field {
+	field, ok := f.FieldOk(name)
+	if !ok {
+		panic("field not found")
+	}
+
+	return field
+}
+
+// FieldOk returns the field from a nested struct. The boolean returns whether
+// the field was found (true) or not (false).
+func (f *Field) FieldOk(name string) (*Field, bool) {
+	value := &f.value
+	// value must be settable so we need to make sure it holds the address of the
+	// variable and not a copy, so we can pass the pointer to strctVal instead of a
+	// copy (which is not assigned to any variable, hence not settable).
+	// see "https://blog.golang.org/laws-of-reflection#TOC_8."
+	if f.value.Kind() != reflect.Ptr {
+		a := f.value.Addr()
+		value = &a
+	}
+	v := strctVal(value.Interface())
+	t := v.Type()
+
+	field, ok := t.FieldByName(name)
+	if !ok {
+		return nil, false
+	}
+
+	return &Field{
+		field: field,
+		value: v.FieldByName(name),
+	}, true
+}

--- a/vendor/github.com/fatih/structs/structs.go
+++ b/vendor/github.com/fatih/structs/structs.go
@@ -1,0 +1,584 @@
+// Package structs contains various utilities functions to work with structs.
+package structs
+
+import (
+	"fmt"
+
+	"reflect"
+)
+
+var (
+	// DefaultTagName is the default tag name for struct fields which provides
+	// a more granular to tweak certain structs. Lookup the necessary functions
+	// for more info.
+	DefaultTagName = "structs" // struct's field default tag name
+)
+
+// Struct encapsulates a struct type to provide several high level functions
+// around the struct.
+type Struct struct {
+	raw     interface{}
+	value   reflect.Value
+	TagName string
+}
+
+// New returns a new *Struct with the struct s. It panics if the s's kind is
+// not struct.
+func New(s interface{}) *Struct {
+	return &Struct{
+		raw:     s,
+		value:   strctVal(s),
+		TagName: DefaultTagName,
+	}
+}
+
+// Map converts the given struct to a map[string]interface{}, where the keys
+// of the map are the field names and the values of the map the associated
+// values of the fields. The default key string is the struct field name but
+// can be changed in the struct field's tag value. The "structs" key in the
+// struct's field tag value is the key name. Example:
+//
+//   // Field appears in map as key "myName".
+//   Name string `structs:"myName"`
+//
+// A tag value with the content of "-" ignores that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// A tag value with the content of "string" uses the stringer to get the value. Example:
+//
+//   // The value will be output of Animal's String() func.
+//   // Map will panic if Animal does not implement String().
+//   Field *Animal `structs:"field,string"`
+//
+// A tag value with the option of "flatten" used in a struct field is to flatten its fields
+// in the output map. Example:
+//
+//   // The FieldStruct's fields will be flattened into the output map.
+//   FieldStruct time.Time `structs:",flatten"`
+//
+// A tag value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Field is not processed further by this package.
+//   Field time.Time     `structs:"myName,omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// A tag value with the option of "omitempty" ignores that particular field if
+// the field value is empty. Example:
+//
+//   // Field appears in map as key "myName", but the field is
+//   // skipped if empty.
+//   Field string `structs:"myName,omitempty"`
+//
+//   // Field appears in map as key "Field" (the default), but
+//   // the field is skipped if empty.
+//   Field string `structs:",omitempty"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields will be neglected.
+func (s *Struct) Map() map[string]interface{} {
+	out := make(map[string]interface{})
+	s.FillMap(out)
+	return out
+}
+
+// FillMap is the same as Map. Instead of returning the output, it fills the
+// given map.
+func (s *Struct) FillMap(out map[string]interface{}) {
+	if out == nil {
+		return
+	}
+
+	fields := s.structFields()
+
+	for _, field := range fields {
+		name := field.Name
+		val := s.value.FieldByName(name)
+		isSubStruct := false
+		var finalVal interface{}
+
+		tagName, tagOpts := parseTag(field.Tag.Get(s.TagName))
+		if tagName != "" {
+			name = tagName
+		}
+
+		// if the value is a zero value and the field is marked as omitempty do
+		// not include
+		if tagOpts.Has("omitempty") {
+			zero := reflect.Zero(val.Type()).Interface()
+			current := val.Interface()
+
+			if reflect.DeepEqual(current, zero) {
+				continue
+			}
+		}
+
+		if !tagOpts.Has("omitnested") {
+			finalVal = s.nested(val)
+
+			v := reflect.ValueOf(val.Interface())
+			if v.Kind() == reflect.Ptr {
+				v = v.Elem()
+			}
+
+			switch v.Kind() {
+			case reflect.Map, reflect.Struct:
+				isSubStruct = true
+			}
+		} else {
+			finalVal = val.Interface()
+		}
+
+		if tagOpts.Has("string") {
+			s, ok := val.Interface().(fmt.Stringer)
+			if ok {
+				out[name] = s.String()
+			}
+			continue
+		}
+
+		if isSubStruct && (tagOpts.Has("flatten")) {
+			for k := range finalVal.(map[string]interface{}) {
+				out[k] = finalVal.(map[string]interface{})[k]
+			}
+		} else {
+			out[name] = finalVal
+		}
+	}
+}
+
+// Values converts the given s struct's field values to a []interface{}.  A
+// struct tag with the content of "-" ignores the that particular field.
+// Example:
+//
+//   // Field is ignored by this package.
+//   Field int `structs:"-"`
+//
+// A value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Fields is not processed further by this package.
+//   Field time.Time     `structs:",omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// A tag value with the option of "omitempty" ignores that particular field and
+// is not added to the values if the field value is empty. Example:
+//
+//   // Field is skipped if empty
+//   Field string `structs:",omitempty"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields  will be neglected.
+func (s *Struct) Values() []interface{} {
+	fields := s.structFields()
+
+	var t []interface{}
+
+	for _, field := range fields {
+		val := s.value.FieldByName(field.Name)
+
+		_, tagOpts := parseTag(field.Tag.Get(s.TagName))
+
+		// if the value is a zero value and the field is marked as omitempty do
+		// not include
+		if tagOpts.Has("omitempty") {
+			zero := reflect.Zero(val.Type()).Interface()
+			current := val.Interface()
+
+			if reflect.DeepEqual(current, zero) {
+				continue
+			}
+		}
+
+		if tagOpts.Has("string") {
+			s, ok := val.Interface().(fmt.Stringer)
+			if ok {
+				t = append(t, s.String())
+			}
+			continue
+		}
+
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+			// look out for embedded structs, and convert them to a
+			// []interface{} to be added to the final values slice
+			t = append(t, Values(val.Interface())...)
+		} else {
+			t = append(t, val.Interface())
+		}
+	}
+
+	return t
+}
+
+// Fields returns a slice of Fields. A struct tag with the content of "-"
+// ignores the checking of that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// It panics if s's kind is not struct.
+func (s *Struct) Fields() []*Field {
+	return getFields(s.value, s.TagName)
+}
+
+// Names returns a slice of field names. A struct tag with the content of "-"
+// ignores the checking of that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// It panics if s's kind is not struct.
+func (s *Struct) Names() []string {
+	fields := getFields(s.value, s.TagName)
+
+	names := make([]string, len(fields))
+
+	for i, field := range fields {
+		names[i] = field.Name()
+	}
+
+	return names
+}
+
+func getFields(v reflect.Value, tagName string) []*Field {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	t := v.Type()
+
+	var fields []*Field
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if tag := field.Tag.Get(tagName); tag == "-" {
+			continue
+		}
+
+		f := &Field{
+			field: field,
+			value: v.FieldByName(field.Name),
+		}
+
+		fields = append(fields, f)
+
+	}
+
+	return fields
+}
+
+// Field returns a new Field struct that provides several high level functions
+// around a single struct field entity. It panics if the field is not found.
+func (s *Struct) Field(name string) *Field {
+	f, ok := s.FieldOk(name)
+	if !ok {
+		panic("field not found")
+	}
+
+	return f
+}
+
+// FieldOk returns a new Field struct that provides several high level functions
+// around a single struct field entity. The boolean returns true if the field
+// was found.
+func (s *Struct) FieldOk(name string) (*Field, bool) {
+	t := s.value.Type()
+
+	field, ok := t.FieldByName(name)
+	if !ok {
+		return nil, false
+	}
+
+	return &Field{
+		field:      field,
+		value:      s.value.FieldByName(name),
+		defaultTag: s.TagName,
+	}, true
+}
+
+// IsZero returns true if all fields in a struct is a zero value (not
+// initialized) A struct tag with the content of "-" ignores the checking of
+// that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// A value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Field is not processed further by this package.
+//   Field time.Time     `structs:"myName,omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields  will be neglected. It panics if s's kind is not struct.
+func (s *Struct) IsZero() bool {
+	fields := s.structFields()
+
+	for _, field := range fields {
+		val := s.value.FieldByName(field.Name)
+
+		_, tagOpts := parseTag(field.Tag.Get(s.TagName))
+
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+			ok := IsZero(val.Interface())
+			if !ok {
+				return false
+			}
+
+			continue
+		}
+
+		// zero value of the given field, such as "" for string, 0 for int
+		zero := reflect.Zero(val.Type()).Interface()
+
+		//  current value of the given field
+		current := val.Interface()
+
+		if !reflect.DeepEqual(current, zero) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// HasZero returns true if a field in a struct is not initialized (zero value).
+// A struct tag with the content of "-" ignores the checking of that particular
+// field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// A value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Field is not processed further by this package.
+//   Field time.Time     `structs:"myName,omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields  will be neglected. It panics if s's kind is not struct.
+func (s *Struct) HasZero() bool {
+	fields := s.structFields()
+
+	for _, field := range fields {
+		val := s.value.FieldByName(field.Name)
+
+		_, tagOpts := parseTag(field.Tag.Get(s.TagName))
+
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+			ok := HasZero(val.Interface())
+			if ok {
+				return true
+			}
+
+			continue
+		}
+
+		// zero value of the given field, such as "" for string, 0 for int
+		zero := reflect.Zero(val.Type()).Interface()
+
+		//  current value of the given field
+		current := val.Interface()
+
+		if reflect.DeepEqual(current, zero) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Name returns the structs's type name within its package. For more info refer
+// to Name() function.
+func (s *Struct) Name() string {
+	return s.value.Type().Name()
+}
+
+// structFields returns the exported struct fields for a given s struct. This
+// is a convenient helper method to avoid duplicate code in some of the
+// functions.
+func (s *Struct) structFields() []reflect.StructField {
+	t := s.value.Type()
+
+	var f []reflect.StructField
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		// we can't access the value of unexported fields
+		if field.PkgPath != "" {
+			continue
+		}
+
+		// don't check if it's omitted
+		if tag := field.Tag.Get(s.TagName); tag == "-" {
+			continue
+		}
+
+		f = append(f, field)
+	}
+
+	return f
+}
+
+func strctVal(s interface{}) reflect.Value {
+	v := reflect.ValueOf(s)
+
+	// if pointer get the underlying element≤
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		panic("not struct")
+	}
+
+	return v
+}
+
+// Map converts the given struct to a map[string]interface{}. For more info
+// refer to Struct types Map() method. It panics if s's kind is not struct.
+func Map(s interface{}) map[string]interface{} {
+	return New(s).Map()
+}
+
+// FillMap is the same as Map. Instead of returning the output, it fills the
+// given map.
+func FillMap(s interface{}, out map[string]interface{}) {
+	New(s).FillMap(out)
+}
+
+// Values converts the given struct to a []interface{}. For more info refer to
+// Struct types Values() method.  It panics if s's kind is not struct.
+func Values(s interface{}) []interface{} {
+	return New(s).Values()
+}
+
+// Fields returns a slice of *Field. For more info refer to Struct types
+// Fields() method.  It panics if s's kind is not struct.
+func Fields(s interface{}) []*Field {
+	return New(s).Fields()
+}
+
+// Names returns a slice of field names. For more info refer to Struct types
+// Names() method.  It panics if s's kind is not struct.
+func Names(s interface{}) []string {
+	return New(s).Names()
+}
+
+// IsZero returns true if all fields is equal to a zero value. For more info
+// refer to Struct types IsZero() method.  It panics if s's kind is not struct.
+func IsZero(s interface{}) bool {
+	return New(s).IsZero()
+}
+
+// HasZero returns true if any field is equal to a zero value. For more info
+// refer to Struct types HasZero() method.  It panics if s's kind is not struct.
+func HasZero(s interface{}) bool {
+	return New(s).HasZero()
+}
+
+// IsStruct returns true if the given variable is a struct or a pointer to
+// struct.
+func IsStruct(s interface{}) bool {
+	v := reflect.ValueOf(s)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// uninitialized zero value of a struct
+	if v.Kind() == reflect.Invalid {
+		return false
+	}
+
+	return v.Kind() == reflect.Struct
+}
+
+// Name returns the structs's type name within its package. It returns an
+// empty string for unnamed types. It panics if s's kind is not struct.
+func Name(s interface{}) string {
+	return New(s).Name()
+}
+
+// nested retrieves recursively all types for the given value and returns the
+// nested value.
+func (s *Struct) nested(val reflect.Value) interface{} {
+	var finalVal interface{}
+
+	v := reflect.ValueOf(val.Interface())
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		n := New(val.Interface())
+		n.TagName = s.TagName
+		m := n.Map()
+
+		// do not add the converted value if there are no exported fields, ie:
+		// time.Time
+		if len(m) == 0 {
+			finalVal = val.Interface()
+		} else {
+			finalVal = m
+		}
+	case reflect.Map:
+		// get the element type of the map
+		mapElem := val.Type()
+		switch val.Type().Kind() {
+		case reflect.Ptr, reflect.Array, reflect.Map,
+			reflect.Slice, reflect.Chan:
+			mapElem = val.Type().Elem()
+			if mapElem.Kind() == reflect.Ptr {
+				mapElem = mapElem.Elem()
+			}
+		}
+
+		// only iterate over struct types, ie: map[string]StructType,
+		// map[string][]StructType,
+		if mapElem.Kind() == reflect.Struct ||
+			(mapElem.Kind() == reflect.Slice &&
+				mapElem.Elem().Kind() == reflect.Struct) {
+			m := make(map[string]interface{}, val.Len())
+			for _, k := range val.MapKeys() {
+				m[k.String()] = s.nested(val.MapIndex(k))
+			}
+			finalVal = m
+			break
+		}
+
+		// TODO(arslan): should this be optional?
+		finalVal = val.Interface()
+	case reflect.Slice, reflect.Array:
+		if val.Type().Kind() == reflect.Interface {
+			finalVal = val.Interface()
+			break
+		}
+
+		// TODO(arslan): should this be optional?
+		// do not iterate of non struct types, just pass the value. Ie: []int,
+		// []string, co... We only iterate further if it's a struct.
+		// i.e []foo or []*foo
+		if val.Type().Elem().Kind() != reflect.Struct &&
+			!(val.Type().Elem().Kind() == reflect.Ptr &&
+				val.Type().Elem().Elem().Kind() == reflect.Struct) {
+			finalVal = val.Interface()
+			break
+		}
+
+		slices := make([]interface{}, val.Len())
+		for x := 0; x < val.Len(); x++ {
+			slices[x] = s.nested(val.Index(x))
+		}
+		finalVal = slices
+	default:
+		finalVal = val.Interface()
+	}
+
+	return finalVal
+}

--- a/vendor/github.com/fatih/structs/tags.go
+++ b/vendor/github.com/fatih/structs/tags.go
@@ -1,0 +1,32 @@
+package structs
+
+import "strings"
+
+// tagOptions contains a slice of tag options
+type tagOptions []string
+
+// Has returns true if the given option is available in tagOptions
+func (t tagOptions) Has(opt string) bool {
+	for _, tagOpt := range t {
+		if tagOpt == opt {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseTag splits a struct field's tag into its name and a list of options
+// which comes after a name. A tag is in the form of: "name,option1,option2".
+// The name can be neglectected.
+func parseTag(tag string) (string, tagOptions) {
+	// tag is one of followings:
+	// ""
+	// "name"
+	// "name,opt"
+	// "name,opt,opt2"
+	// ",opt"
+
+	res := strings.Split(tag, ",")
+	return res[0], res[1:]
+}

--- a/vendor/github.com/matryer/resync/.gitignore
+++ b/vendor/github.com/matryer/resync/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/matryer/resync/LICENSE
+++ b/vendor/github.com/matryer/resync/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mat Ryer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/matryer/resync/README.md
+++ b/vendor/github.com/matryer/resync/README.md
@@ -1,0 +1,29 @@
+# resync
+
+`sync.Once` with `Reset()`
+
+  * See [sync.Once](http://golang.org/pkg/sync/#Once)
+
+Rather than adding this project as a dependency, consider [dropping](https://github.com/matryer/drop) this file into your project.
+
+## Example
+
+The following example examines how `resync.Once` could be used in a HTTP server situation.
+
+```go
+// use it just like sync.Once
+var once resync.Once
+
+// handle a web request
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	once.Do(func(){
+		// load templates or something
+	})
+	// TODO: respond
+}
+
+// handle some request that indicates things have changed
+func handleResetRequest(w http.ResponseWriter, r *http.Request) {
+	once.Reset() // call Reset to cause initialisation to happen again above
+}
+```

--- a/vendor/github.com/matryer/resync/once.go
+++ b/vendor/github.com/matryer/resync/once.go
@@ -1,0 +1,38 @@
+package resync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Once is an object that will perform exactly one action
+// until Reset is called.
+// See http://golang.org/pkg/sync/#Once
+type Once struct {
+	m    sync.Mutex
+	done uint32
+}
+
+// Do simulates sync.Once.Do by executing the specified function
+// only once, until Reset is called.
+// See http://golang.org/pkg/sync/#Once
+func (o *Once) Do(f func()) {
+	if atomic.LoadUint32(&o.done) == 1 {
+		return
+	}
+	// Slow-path.
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.done == 0 {
+		defer atomic.StoreUint32(&o.done, 1)
+		f()
+	}
+}
+
+// Reset indicates that the next call to Do should actually be called
+// once again.
+func (o *Once) Reset() {
+	o.m.Lock()
+	defer o.m.Unlock()
+	atomic.StoreUint32(&o.done, 0)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,6 +88,8 @@ github.com/caarlos0/env
 # github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261
 ## explicit
 github.com/certifi/gocertifi
+# github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927
+## explicit
 # github.com/codegangsta/negroni v1.0.0
 ## explicit
 # github.com/davecgh/go-spew v1.1.1
@@ -209,6 +211,9 @@ github.com/lib/pq/scram
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/matryer/resync v0.0.0-20161211202428-d39c09a11215
+## explicit
+github.com/matryer/resync
 # github.com/mattn/go-sqlite3 v1.14.0
 github.com/mattn/go-sqlite3
 # github.com/matttproud/golang_protobuf_extensions v1.0.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,6 +12,9 @@ cloud.google.com/go/pubsub/pstest
 # github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a
 ## explicit
 github.com/DataDog/datadog-go/statsd
+# github.com/Knetic/govaluate v3.0.0+incompatible
+## explicit
+github.com/Knetic/govaluate
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
@@ -107,6 +110,9 @@ github.com/eapache/queue
 # github.com/evalphobia/logrus_sentry v0.4.6
 ## explicit
 github.com/evalphobia/logrus_sentry
+# github.com/fatih/structs v1.1.0
+## explicit
+github.com/fatih/structs
 # github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03
 ## explicit
 github.com/getsentry/raven-go


### PR DESCRIPTION
## Description
This changes adds customizable validation rules for _enabled_ flags using https://github.com/Knetic/govaluate.  The rules are specified via new environment variables in the `env.go`; a list of govaluate boolean expressions to be evaluated for flags (a `[]string`), and a connecting operation (either `OR` or `AND`).  When someone uses the API operations `setFlagEnabled` or `putFlag` and the flag is `enabled=true`, we convert the flag into a `map[string]interface{}` so that the properties of the flag are parameters for the govaluate expression.  Then, we iterate through the govaluate expressions in order; if the boolean result of the govaluate expression is `true` then the flag has passed that rule.  Depending on the operation, at least one or all the rules must pass.  If the flag doesn't meet this criteria, a 400 request is returned to the client and the flag update is not saved. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Our team is trying to keep more aware of how flags are being used on our project.  Specifically we want to associated a flag with an owning project in our JIRA system, so we can provide the teams some info about how the flag is being used (e.g. if the flag in practice always returns the same segment for a period of time).  We landed on using a tag to track this relationship, and we wanted to automate user feedback making sure they assign a tag when the flag is active.  Doing this validation only when a flag is set to enabled seemed like the best way; the user can create and configure the flag without validation up until they enable it for actual use. 

<!--- If it fixes an open issue, please link to the issue here. -->
I mentioned this change in this issue at the end: https://github.com/checkr/flagr/issues/428

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I initially prototyped using govaluate for this usecase here: https://github.com/sesquipedalian-dev/govaluate-experiment/blob/main/main.go

In addition to adding unit tests covering the new validation rules, I followed a manual test procedure: 
0) environment: Macbook Pro, OSX 10.15.5, chrome browser, go 1.15.6
1) `make run_ui`
2) `FLAGR_ENABLED_FLAG_VALIDATION_RULES='any("regexMatch(Value, \"^JIRA:[a-zA-Z]{3}[a-zA-Z]*$\")", Tags)' make run`
3) in a browser at `localhost:8080` create a new flag with description 'New flag'
4) in the browser open developer tools to follow along with the network calls
5) Click the toggle button to enable the flag, observe you get an error message and the network tab indicates a 400
![Screen Shot 2021-01-25 at 10 47 34 AM](https://user-images.githubusercontent.com/23544853/105748967-08f75e00-5f00-11eb-960e-9300d43d4bac.png)
6) Reload the page (verify the flag in the DB is not actually enabled) - small UI bug here in that the toggle remains 'enabled' in the UI even though the network call failed
7) Add a tag to the flag matching the critera (e.g. `JIRA:EPLT`)
8) Click the toggle button to enable, observe no error message this time and the network call has a 200 status
9) Remove the tag from the flag
10) change the flag description by adding some characters, and click 'save'.  Observe you again get an error message as in step (5)
11)Add the tag back in and save again, observe no error message

I didn't test other areas of the code too much manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.