### PR TITLE
Support method OPTIONS for CORS

### DIFF
--- a/pkg/config/middleware.go
+++ b/pkg/config/middleware.go
@@ -73,11 +73,12 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 
 	if Config.CORSEnabled {
 		n.Use(cors.New(cors.Options{
-			AllowedOrigins:   Config.CORSAllowedOrigins,
-			AllowedHeaders:   Config.CORSAllowedHeaders,
-			ExposedHeaders:   Config.CORSExposedHeaders,
-			AllowedMethods:   Config.CORSAllowedMethods,
-			AllowCredentials: Config.CORSAllowCredentials,
+			AllowedOrigins:     Config.CORSAllowedOrigins,
+			AllowedHeaders:     Config.CORSAllowedHeaders,
+			ExposedHeaders:     Config.CORSExposedHeaders,
+			AllowedMethods:     Config.CORSAllowedMethods,
+			AllowCredentials:   Config.CORSAllowCredentials,
+			OptionsPassthrough: true,
 		}))
 	}
 
@@ -126,7 +127,8 @@ func setupRecoveryMiddleware() *negroni.Recovery {
 	return r
 }
 
-/**
+/*
+*
 setupJWTAuthMiddleware setup an JWTMiddleware from the ENV config
 */
 func setupJWTAuthMiddleware() *jwtAuth {
@@ -220,7 +222,8 @@ func (a *jwtAuth) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.
 	a.JWTMiddleware.HandlerWithNext(w, req, next)
 }
 
-/**
+/*
+*
 setupBasicAuthMiddleware setup an BasicMiddleware from the ENV config
 */
 func setupBasicAuthMiddleware() *basicAuth {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, Prefight request (OPTIONS method) is not supported, will cause CORS error

## Motivation and Context
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Rebuild docker image
- Run the following command from terminal in container
```bash
$ curl -H 'Origin: https://example.com' -v localhost:18000/api/v1/health
*   Trying 127.0.0.1:18000...
* Connected to flagr (127.0.0.1) port 18000 (#0)
> GET /api/v1/health HTTP/1.1
> Host: localhost:18000
> User-Agent: curl/7.81.0
> Accept: */*
> Origin: https://example.com
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: Www-Authenticate
< Content-Type: application/json
< Vary: Origin
< Date: Sun, 11 Sep 2022 07:42:22 GMT
< Content-Length: 16
< 
{"status":"OK"}
* Connection #0 to host flagr left intact
```

- Run by fetch/xhr in my project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.