### PR TITLE
Fix "attempt to write a readonly database"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ ENV FLAGR_DB_DBCONNECTIONSTR=/data/demo_sqlite3.db
 ENV FLAGR_RECORDER_ENABLED=false
 
 COPY --from=npm_builder /go/src/github.com/openflagr/flagr/browser/flagr-ui/dist ./browser/flagr-ui/dist
-ADD ./buildscripts/demo_sqlite3.db /data/demo_sqlite3.db
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
+
+ADD --chown=appuser:appgroup ./buildscripts/demo_sqlite3.db /data/demo_sqlite3.db
 
 EXPOSE 18000
 CMD ./flagr


### PR DESCRIPTION
With adding the appuser when copying in the demo db the appuser doesn't have permission to write to it since docker defaults to adding this as root. This adds the demo db with the correct permissions. 

Closes #502 #503
