### PR TITLE
bump docker action version

### DIFF
--- a/.github/workflows/cd_docker.yml
+++ b/.github/workflows/cd_docker.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Publish Docker SemVer Tag
-      uses: elgohr/Publish-Docker-Github-Action@3.04
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: openflagr/flagr
         username: ${{ github.actor }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update [the Publish-Docker-Github-Action](https://github.com/elgohr/Publish-Docker-Github-Action) version to support multi-arch image build. 

## Motivation and Context
The [multi-arch image build feature](https://github.com/elgohr/Publish-Docker-Github-Action/commit/cbaa32c746a1b98fb0db99bbbff92ad4aa733b44) in the Publish-Docker-Github-Action is not supported until v4 and v5. 3.04 is currently in use in this repository.

## How Has This Been Tested?
Tested in the forked repo here - https://github.com/kewei5zhang/flagr/actions/runs/3907752432/jobs/6677281328 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.