### PR TITLE
Add concurrent processing for the batch endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 require (
 	cloud.google.com/go/pubsub v1.28.0
 	github.com/newrelic/go-agent v2.1.0+incompatible
+	github.com/samber/lo v1.37.0
 	gorm.io/driver/mysql v1.4.5
 	gorm.io/driver/postgres v1.4.6
 	gorm.io/driver/sqlite v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBO
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
 github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/samber/lo v1.37.0 h1:XjVcB8g6tgUp8rsPsJ2CvhClfImrpL04YpQHXeHPhRw=
+github.com/samber/lo v1.37.0/go.mod h1:9vaz2O4o8oOnK23pd2TrXufcbdbJIa3b6cstBWKpopA=
 github.com/secure-systems-lab/go-securesystemslib v0.3.1/go.mod h1:o8hhjkbNl2gOamKUA/eNW3xUrntHT9L4W89W1nfj43U=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=

--- a/pkg/handler/fixture.go
+++ b/pkg/handler/fixture.go
@@ -7,18 +7,27 @@ import (
 
 // GenFixtureEvalCache generates a fixture
 func GenFixtureEvalCache() *EvalCache {
-	f := entity.GenFixtureFlag()
+	f1 := entity.GenFixtureFlag()
 
-	tagCache := make(map[string]map[uint]*entity.Flag)
-	for _, tag := range f.Tags {
-		tagCache[tag.Value] = map[uint]*entity.Flag{f.ID: &f}
-	}
+	f2 := entity.GenFixtureFlag()
+	f2.Key = "flag_key_101"
+	f2.ID = 101
+	f2.Tags = []entity.Tag{{Value: "tag2"}}
 
 	ec := &EvalCache{}
 	ec.cache.Store(&cacheContainer{
-		idCache:  map[string]*entity.Flag{util.SafeString(f.ID): &f},
-		keyCache: map[string]*entity.Flag{f.Key: &f},
-		tagCache: tagCache,
+		idCache: map[string]*entity.Flag{
+			util.SafeString(f1.ID): &f1,
+			util.SafeString(f2.ID): &f2,
+		},
+		keyCache: map[string]*entity.Flag{
+			f1.Key: &f1,
+			f2.Key: &f2,
+		},
+		tagCache: map[string]map[uint]*entity.Flag{
+			"tag1": {f1.ID: &f1},
+			"tag2": {f1.ID: &f1, f2.ID: &f2},
+		},
 	})
 
 	return ec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Make all the batch endpoint actually concurrent. To speedup the processing of hundreds of flags in parallel.
- Add a `lo` package for the `lop.Map` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

- Unit tests with more EvalMultiFlags tests
- Local benchmark

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.