### PR TITLE
Add CaFile for KafkaRecorder when simpleSSL enabled

### DIFF
--- a/pkg/handler/data_recorder_kafka.go
+++ b/pkg/handler/data_recorder_kafka.go
@@ -91,23 +91,14 @@ var NewKafkaRecorder = func() DataRecorder {
 }
 
 func createTLSConfiguration(certFile string, keyFile string, caFile string, verifySSL bool, simpleSSL bool) (t *tls.Config) {
-	if certFile != "" && keyFile != "" && caFile != "" {
+	if certFile != "" && keyFile != "" {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
 			logrus.WithField("TLSConfigurationError", err).Panic(err)
 		}
 
-		caCert, err := os.ReadFile(caFile)
-		if err != nil {
-			logrus.WithField("TLSConfigurationError", err).Panic(err)
-		}
-
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
-
 		t = &tls.Config{
 			Certificates:       []tls.Certificate{cert},
-			RootCAs:            caCertPool,
 			InsecureSkipVerify: !verifySSL,
 		}
 	}
@@ -116,6 +107,17 @@ func createTLSConfiguration(certFile string, keyFile string, caFile string, veri
 		t = &tls.Config{
 			InsecureSkipVerify: !verifySSL,
 		}
+	}
+
+	if caFile != "" && t != nil {
+		caCert, err := os.ReadFile(caFile)
+		if err != nil {
+			logrus.WithField("TLSConfigurationError", err).Panic(err)
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		t.RootCAs = caCertPool
 	}
 	// will be nil by default if nothing is provided
 	return t


### PR DESCRIPTION
## Description
Currently, there is no way to add CaFile, when SASL_SSL enabled. This pull request add CaFile for KafkaRecorder when simpleSSL enabled

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.