### PR TITLE
Add option FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -128,25 +128,26 @@ var Config = struct {
 	RecorderFrameOutputMode string `env:"FLAGR_RECORDER_FRAME_OUTPUT_MODE" envDefault:"payload_string"`
 
 	// Kafka related configurations for data records logging (Flagr Metrics)
-	RecorderKafkaVersion          string        `env:"FLAGR_RECORDER_KAFKA_VERSION" envDefault:"0.8.2.0"`
-	RecorderKafkaBrokers          string        `env:"FLAGR_RECORDER_KAFKA_BROKERS" envDefault:":9092"`
-	RecorderKafkaCompressionCodec int8          `env:"FLAGR_RECORDER_KAFKA_COMPRESSION_CODEC" envDefault:"0"`
-	RecorderKafkaCertFile         string        `env:"FLAGR_RECORDER_KAFKA_CERTFILE" envDefault:""`
-	RecorderKafkaKeyFile          string        `env:"FLAGR_RECORDER_KAFKA_KEYFILE" envDefault:""`
-	RecorderKafkaCAFile           string        `env:"FLAGR_RECORDER_KAFKA_CAFILE" envDefault:""`
-	RecorderKafkaVerifySSL        bool          `env:"FLAGR_RECORDER_KAFKA_VERIFYSSL" envDefault:"false"`
-	RecorderKafkaSimpleSSL        bool          `env:"FLAGR_RECORDER_KAFKA_SIMPLE_SSL" envDefault:"false"`
-	RecorderKafkaSASLUsername     string        `env:"FLAGR_RECORDER_KAFKA_SASL_USERNAME" envDefault:""`
-	RecorderKafkaSASLPassword     string        `env:"FLAGR_RECORDER_KAFKA_SASL_PASSWORD" envDefault:""`
-	RecorderKafkaVerbose          bool          `env:"FLAGR_RECORDER_KAFKA_VERBOSE" envDefault:"true"`
-	RecorderKafkaTopic            string        `env:"FLAGR_RECORDER_KAFKA_TOPIC" envDefault:"flagr-records"`
-	RecorderKafkaRetryMax         int           `env:"FLAGR_RECORDER_KAFKA_RETRYMAX" envDefault:"5"`
-	RecorderKafkaMaxOpenReqs      int           `env:"FLAGR_RECORDER_KAFKA_MAXOPENREQUESTS" envDefault:"5"`
-	RecorderKafkaRequiredAcks     int           `env:"FLAGR_RECORDER_KAFKA_REQUIRED_ACKS" envDefault:"1"` // 0: no response, 1: wait for local, -1: wait for all
-	RecorderKafkaIdempotent       bool          `env:"FLAGR_RECORDER_KAFKA_IDEMPOTENT" envDefault:"false"`
-	RecorderKafkaFlushFrequency   time.Duration `env:"FLAGR_RECORDER_KAFKA_FLUSHFREQUENCY" envDefault:"500ms"`
-	RecorderKafkaEncrypted        bool          `env:"FLAGR_RECORDER_KAFKA_ENCRYPTED" envDefault:"false"`
-	RecorderKafkaEncryptionKey    string        `env:"FLAGR_RECORDER_KAFKA_ENCRYPTION_KEY" envDefault:""`
+	RecorderKafkaVersion             string        `env:"FLAGR_RECORDER_KAFKA_VERSION" envDefault:"0.8.2.0"`
+	RecorderKafkaBrokers             string        `env:"FLAGR_RECORDER_KAFKA_BROKERS" envDefault:":9092"`
+	RecorderKafkaCompressionCodec    int8          `env:"FLAGR_RECORDER_KAFKA_COMPRESSION_CODEC" envDefault:"0"`
+	RecorderKafkaCertFile            string        `env:"FLAGR_RECORDER_KAFKA_CERTFILE" envDefault:""`
+	RecorderKafkaKeyFile             string        `env:"FLAGR_RECORDER_KAFKA_KEYFILE" envDefault:""`
+	RecorderKafkaCAFile              string        `env:"FLAGR_RECORDER_KAFKA_CAFILE" envDefault:""`
+	RecorderKafkaVerifySSL           bool          `env:"FLAGR_RECORDER_KAFKA_VERIFYSSL" envDefault:"false"`
+	RecorderKafkaSimpleSSL           bool          `env:"FLAGR_RECORDER_KAFKA_SIMPLE_SSL" envDefault:"false"`
+	RecorderKafkaSASLUsername        string        `env:"FLAGR_RECORDER_KAFKA_SASL_USERNAME" envDefault:""`
+	RecorderKafkaSASLPassword        string        `env:"FLAGR_RECORDER_KAFKA_SASL_PASSWORD" envDefault:""`
+	RecorderKafkaVerbose             bool          `env:"FLAGR_RECORDER_KAFKA_VERBOSE" envDefault:"true"`
+	RecorderKafkaTopic               string        `env:"FLAGR_RECORDER_KAFKA_TOPIC" envDefault:"flagr-records"`
+	RecorderKafkaPartitionKeyEnabled bool          `env:"FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED" envDefault:"true"`
+	RecorderKafkaRetryMax            int           `env:"FLAGR_RECORDER_KAFKA_RETRYMAX" envDefault:"5"`
+	RecorderKafkaMaxOpenReqs         int           `env:"FLAGR_RECORDER_KAFKA_MAXOPENREQUESTS" envDefault:"5"`
+	RecorderKafkaRequiredAcks        int           `env:"FLAGR_RECORDER_KAFKA_REQUIRED_ACKS" envDefault:"1"` // 0: no response, 1: wait for local, -1: wait for all
+	RecorderKafkaIdempotent          bool          `env:"FLAGR_RECORDER_KAFKA_IDEMPOTENT" envDefault:"false"`
+	RecorderKafkaFlushFrequency      time.Duration `env:"FLAGR_RECORDER_KAFKA_FLUSHFREQUENCY" envDefault:"500ms"`
+	RecorderKafkaEncrypted           bool          `env:"FLAGR_RECORDER_KAFKA_ENCRYPTED" envDefault:"false"`
+	RecorderKafkaEncryptionKey       string        `env:"FLAGR_RECORDER_KAFKA_ENCRYPTION_KEY" envDefault:""`
 
 	// Kinesis related configurations for data records logging (Flagr Metrics)
 	RecorderKinesisStreamName          string        `env:"FLAGR_RECORDER_KINESIS_STREAM_NAME" envDefault:"flagr-records"`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add option FLAGR_RECORDER_KAFKA_PARTITION_KEY_ENABLED

## Motivation and Context
We have entity id that contains only user's segment. When google bot come to our site we have many messages in only one partition in kafka. This pull request disable key partition, so messages come to random partition but without order guarantee.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.