### PR TITLE
Fix: set correct error variable when put distributions

### DIFF
--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -574,7 +574,7 @@ func (c *crud) PutDistributions(params distribution.PutDistributionsParams) midd
 		err1 := tx.Create(&d).Error
 		if err1 != nil {
 			tx.Rollback()
-			return distribution.NewPutDistributionsDefault(500).WithPayload(ErrorMessage("%s", err))
+			return distribution.NewPutDistributionsDefault(500).WithPayload(ErrorMessage("%s", err1))
 		}
 	}
 	err = tx.Commit().Error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hi everyone involved! 
I noticed that if an error occurs on the DB side during the put distributions operation, a non-user-friendly message appeared in the popup dialog (see below). A quick analysis of the code revealed that the wrong error variable is passed to the response. 
![image](https://github.com/openflagr/flagr/assets/105417439/4bc9dfb0-206e-45c1-afa1-cbe049301bde)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If something goes wrong when updating distribution, a user-friendly error message should be displayed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
_It's a super clear, one-line fix that does not require any special testing or any additional effort._

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.