### PR TITLE
Support snapshot pagination

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -790,6 +790,18 @@ paths:
           type: integer
           format: int64
           minimum: 1
+        - in: query
+          name: limit
+          type: integer
+          format: int64
+          description: the number of snapshots to return
+        - in: query
+          name: offset
+          type: integer
+          format: int64
+          description: >-
+            return snapshots given the offset, it should usually set together
+            with limit
       responses:
         '200':
           description: returns the flag snapshots
@@ -1063,6 +1075,7 @@ definitions:
         type: integer
         format: int64
         minimum: 1
+        readOnly: true
       updatedBy:
         type: string
       flag:

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -799,9 +799,7 @@ paths:
           name: offset
           type: integer
           format: int64
-          description: >-
-            return snapshots given the offset, it should usually set together
-            with limit
+          description: return snapshots given the offset, it should usually set together with limit
       responses:
         '200':
           description: returns the flag snapshots

--- a/pkg/mapper/entity_restapi/e2r/e2r.go
+++ b/pkg/mapper/entity_restapi/e2r/e2r.go
@@ -56,7 +56,7 @@ func MapFlagSnapshot(e *entity.FlagSnapshot) (*models.FlagSnapshot, error) {
 	}
 	r := &models.FlagSnapshot{
 		Flag:      f,
-		ID:        util.Int64Ptr(int64(e.ID)),
+		ID:        int64(e.ID),
 		UpdatedBy: e.UpdatedBy,
 		UpdatedAt: util.StringPtr(e.UpdatedAt.UTC().Format(time.RFC3339)),
 	}

--- a/swagger/flag_snapshots.yaml
+++ b/swagger/flag_snapshots.yaml
@@ -10,6 +10,16 @@ get:
       type: integer
       format: int64
       minimum: 1
+    - in: query
+      name: limit
+      type: integer
+      format: int64
+      description: the number of snapshots to return
+    - in: query
+      name: offset
+      type: integer
+      format: int64
+      description: return snapshots given the offset, it should usually set together with limit
   responses:
     200:
       description: returns the flag snapshots

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -203,6 +203,7 @@ definitions:
         type: integer
         format: int64
         minimum: 1
+        readOnly: true
       updatedBy:
         type: string
       flag:

--- a/swagger_gen/models/flag_snapshot.go
+++ b/swagger_gen/models/flag_snapshot.go
@@ -25,8 +25,9 @@ type FlagSnapshot struct {
 
 	// id
 	// Required: true
+	// Read Only: true
 	// Minimum: 1
-	ID *int64 `json:"id"`
+	ID int64 `json:"id"`
 
 	// updated at
 	// Required: true
@@ -81,11 +82,11 @@ func (m *FlagSnapshot) validateFlag(formats strfmt.Registry) error {
 
 func (m *FlagSnapshot) validateID(formats strfmt.Registry) error {
 
-	if err := validate.Required("id", "body", m.ID); err != nil {
+	if err := validate.Required("id", "body", int64(m.ID)); err != nil {
 		return err
 	}
 
-	if err := validate.MinimumInt("id", "body", *m.ID, 1, false); err != nil {
+	if err := validate.MinimumInt("id", "body", m.ID, 1, false); err != nil {
 		return err
 	}
 
@@ -113,6 +114,10 @@ func (m *FlagSnapshot) ContextValidate(ctx context.Context, formats strfmt.Regis
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateID(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -131,6 +136,15 @@ func (m *FlagSnapshot) contextValidateFlag(ctx context.Context, formats strfmt.R
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *FlagSnapshot) contextValidateID(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "id", "body", int64(m.ID)); err != nil {
+		return err
 	}
 
 	return nil

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -993,6 +993,20 @@ func init() {
             "name": "flagID",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "the number of snapshots to return",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "return snapshots given the offset, it should usually set together with limit",
+            "name": "offset",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1799,7 +1813,8 @@ func init() {
         "id": {
           "type": "integer",
           "format": "int64",
-          "minimum": 1
+          "minimum": 1,
+          "readOnly": true
         },
         "updatedAt": {
           "type": "string",
@@ -3057,6 +3072,20 @@ func init() {
             "name": "flagID",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "the number of snapshots to return",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "return snapshots given the offset, it should usually set together with limit",
+            "name": "offset",
+            "in": "query"
           }
         ],
         "responses": {
@@ -3865,7 +3894,8 @@ func init() {
         "id": {
           "type": "integer",
           "format": "int64",
-          "minimum": 1
+          "minimum": 1,
+          "readOnly": true
         },
         "updatedAt": {
           "type": "string",

--- a/swagger_gen/restapi/operations/flag/get_flag_snapshots_parameters.go
+++ b/swagger_gen/restapi/operations/flag/get_flag_snapshots_parameters.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -38,6 +39,14 @@ type GetFlagSnapshotsParams struct {
 	  In: path
 	*/
 	FlagID int64
+	/*the number of snapshots to return
+	  In: query
+	*/
+	Limit *int64
+	/*return snapshots given the offset, it should usually set together with limit
+	  In: query
+	*/
+	Offset *int64
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -49,8 +58,20 @@ func (o *GetFlagSnapshotsParams) BindRequest(r *http.Request, route *middleware.
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
 	rFlagID, rhkFlagID, _ := route.Params.GetOK("flagID")
 	if err := o.bindFlagID(rFlagID, rhkFlagID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qLimit, qhkLimit, _ := qs.GetOK("limit")
+	if err := o.bindLimit(qLimit, qhkLimit, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOffset, qhkOffset, _ := qs.GetOK("offset")
+	if err := o.bindOffset(qOffset, qhkOffset, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -88,6 +109,52 @@ func (o *GetFlagSnapshotsParams) validateFlagID(formats strfmt.Registry) error {
 	if err := validate.MinimumInt("flagID", "path", o.FlagID, 1, false); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// bindLimit binds and validates parameter Limit from query.
+func (o *GetFlagSnapshotsParams) bindLimit(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertInt64(raw)
+	if err != nil {
+		return errors.InvalidType("limit", "query", "int64", raw)
+	}
+	o.Limit = &value
+
+	return nil
+}
+
+// bindOffset binds and validates parameter Offset from query.
+func (o *GetFlagSnapshotsParams) bindOffset(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertInt64(raw)
+	if err != nil {
+		return errors.InvalidType("offset", "query", "int64", raw)
+	}
+	o.Offset = &value
 
 	return nil
 }

--- a/swagger_gen/restapi/operations/flag/get_flag_snapshots_urlbuilder.go
+++ b/swagger_gen/restapi/operations/flag/get_flag_snapshots_urlbuilder.go
@@ -18,6 +18,9 @@ import (
 type GetFlagSnapshotsURL struct {
 	FlagID int64
 
+	Limit  *int64
+	Offset *int64
+
 	_basePath string
 	// avoid unkeyed usage
 	_ struct{}
@@ -56,6 +59,26 @@ func (o *GetFlagSnapshotsURL) Build() (*url.URL, error) {
 		_basePath = "/api/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var limitQ string
+	if o.Limit != nil {
+		limitQ = swag.FormatInt64(*o.Limit)
+	}
+	if limitQ != "" {
+		qs.Set("limit", limitQ)
+	}
+
+	var offsetQ string
+	if o.Offset != nil {
+		offsetQ = swag.FormatInt64(*o.Offset)
+	}
+	if offsetQ != "" {
+		qs.Set("offset", offsetQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }


### PR DESCRIPTION
## Description
Support `limit` and `offset` query parameters in the `getFlagSnapshots` API.

## Motivation and Context
This change allows flag snapshots to be retrieved from the API using pagination, so you don't have to fetch all snapshots at once which can be slow for flags with many snapshots.

## How Has This Been Tested?
Tested locally that the API is backwards compatible, such that it retrieves all snapshots when the query parameters are omitted:

```
curl http://localhost:18000/api/v1/flags/1/snapshots
```
```
[
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kgemgm1zhty1431sp",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-04T16:55:51.882-04:00",
      "variants": []
    },
    "id": 3,
    "updatedAt": "2023-10-04T20:55:51Z"
  },
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": true,
      "id": 1,
      "key": "kgemgm1zhty1431sp",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-04T16:55:43.463-04:00",
      "variants": []
    },
    "id": 2,
    "updatedAt": "2023-10-04T20:55:43Z"
  },
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kgemgm1zhty1431sp",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-04T16:55:38.469-04:00",
      "variants": []
    },
    "id": 1,
    "updatedAt": "2023-10-04T20:55:38Z"
  }
]
```

Tested locally that the new parameters worked:
```
curl http://localhost:18000/api/v1/flags/1/snapshots\?limit\=1
```
```
[
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kgemgm1zhty1431sp",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-04T16:55:51.882-04:00",
      "variants": []
    },
    "id": 3,
    "updatedAt": "2023-10-04T20:55:51Z"
  }
]
```
```
curl http://localhost:18000/api/v1/flags/1/snapshots\?limit\=2\&offset\=1
```
```
[
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": true,
      "id": 1,
      "key": "kgemgm1zhty1431sp",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-04T16:55:43.463-04:00",
      "variants": []
    },
    "id": 2,
    "updatedAt": "2023-10-04T20:55:43Z"
  },
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kgemgm1zhty1431sp",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-04T16:55:38.469-04:00",
      "variants": []
    },
    "id": 1,
    "updatedAt": "2023-10-04T20:55:38Z"
  }
]
```

Additionally, unit tests were added for the new functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.