### PR TITLE
Add sort parameter to getFlagSnapshots API

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -800,6 +800,13 @@ paths:
           type: integer
           format: int64
           description: return snapshots given the offset, it should usually set together with limit
+        - in: query
+          name: sort
+          type: string
+          enum:
+            - ASC
+            - DESC
+          description: sort order
       responses:
         '200':
           description: returns the flag snapshots

--- a/pkg/handler/crud.go
+++ b/pkg/handler/crud.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // CRUD is the CRUD interface
@@ -180,8 +181,18 @@ func (c *crud) GetFlagSnapshots(params flag.GetFlagSnapshotsParams) middleware.R
 		tx = tx.Offset(int(*params.Offset))
 	}
 
+	descending := true
+	if params.Sort != nil && *params.Sort == "ASC" {
+		descending = false
+	}
+
 	if err := tx.
-		Order("created_at desc").
+		Order(clause.OrderByColumn{
+			Column: clause.Column{
+				Name: "created_at",
+			},
+			Desc: descending,
+		}).
 		Where(entity.FlagSnapshot{FlagID: util.SafeUint(params.FlagID)}).
 		Find(&fs).Error; err != nil {
 		return flag.NewGetFlagSnapshotsDefault(500).WithPayload(

--- a/swagger/flag_snapshots.yaml
+++ b/swagger/flag_snapshots.yaml
@@ -20,6 +20,13 @@ get:
       type: integer
       format: int64
       description: return snapshots given the offset, it should usually set together with limit
+    - in: query
+      name: sort
+      type: string
+      enum:
+        - ASC
+        - DESC
+      description: sort order
   responses:
     200:
       description: returns the flag snapshots

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1007,6 +1007,16 @@ func init() {
             "description": "return snapshots given the offset, it should usually set together with limit",
             "name": "offset",
             "in": "query"
+          },
+          {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string",
+            "description": "sort order",
+            "name": "sort",
+            "in": "query"
           }
         ],
         "responses": {
@@ -3085,6 +3095,16 @@ func init() {
             "format": "int64",
             "description": "return snapshots given the offset, it should usually set together with limit",
             "name": "offset",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string",
+            "description": "sort order",
+            "name": "sort",
             "in": "query"
           }
         ],

--- a/swagger_gen/restapi/operations/flag/get_flag_snapshots_parameters.go
+++ b/swagger_gen/restapi/operations/flag/get_flag_snapshots_parameters.go
@@ -47,6 +47,10 @@ type GetFlagSnapshotsParams struct {
 	  In: query
 	*/
 	Offset *int64
+	/*sort order
+	  In: query
+	*/
+	Sort *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -72,6 +76,11 @@ func (o *GetFlagSnapshotsParams) BindRequest(r *http.Request, route *middleware.
 
 	qOffset, qhkOffset, _ := qs.GetOK("offset")
 	if err := o.bindOffset(qOffset, qhkOffset, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qSort, qhkSort, _ := qs.GetOK("sort")
+	if err := o.bindSort(qSort, qhkSort, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -155,6 +164,38 @@ func (o *GetFlagSnapshotsParams) bindOffset(rawData []string, hasKey bool, forma
 		return errors.InvalidType("offset", "query", "int64", raw)
 	}
 	o.Offset = &value
+
+	return nil
+}
+
+// bindSort binds and validates parameter Sort from query.
+func (o *GetFlagSnapshotsParams) bindSort(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Sort = &raw
+
+	if err := o.validateSort(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateSort carries on validations for parameter Sort
+func (o *GetFlagSnapshotsParams) validateSort(formats strfmt.Registry) error {
+
+	if err := validate.EnumCase("sort", "query", *o.Sort, []interface{}{"ASC", "DESC"}, true); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/swagger_gen/restapi/operations/flag/get_flag_snapshots_urlbuilder.go
+++ b/swagger_gen/restapi/operations/flag/get_flag_snapshots_urlbuilder.go
@@ -20,6 +20,7 @@ type GetFlagSnapshotsURL struct {
 
 	Limit  *int64
 	Offset *int64
+	Sort   *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -76,6 +77,14 @@ func (o *GetFlagSnapshotsURL) Build() (*url.URL, error) {
 	}
 	if offsetQ != "" {
 		qs.Set("offset", offsetQ)
+	}
+
+	var sortQ string
+	if o.Sort != nil {
+		sortQ = *o.Sort
+	}
+	if sortQ != "" {
+		qs.Set("sort", sortQ)
 	}
 
 	_result.RawQuery = qs.Encode()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a `sort` parameter with values `ASC` and `DESC` to the `getFlagSnapshots` API.

## Motivation and Context
This change allows API users to receive snapshots in ascending order if they wish to, rather than always receiving results in descending order (the current behavior).

## How Has This Been Tested?

Tested locally that the change is backwards compatible, such that snapshots are received in descending order when the query parameter is not specified:

```
curl http://localhost:18000/api/v1/flags/1/snapshots\?limit\=2

[
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kxjfenfcgu4xdcyq1",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-06T16:10:55.490-04:00",
      "variants": []
    },
    "id": 5,
    "updatedAt": "2023-10-06T20:10:55Z"
  },
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kxjfenfcgu4xdcyq1",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-06T16:10:55.080-04:00",
      "variants": []
    },
    "id": 4,
    "updatedAt": "2023-10-06T20:10:55Z"
  }
]
```

Tested locally that snapshots are received in ascending order when specified:

```
curl http://localhost:18000/api/v1/flags/1/snapshots\?limit\=2\&sort\=ASC

[
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kxjfenfcgu4xdcyq1",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-06T16:10:50.781-04:00",
      "variants": []
    },
    "id": 1,
    "updatedAt": "2023-10-06T20:10:50Z"
  },
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kxjfenfcgu4xdcyq1",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-06T16:10:54.208-04:00",
      "variants": []
    },
    "id": 2,
    "updatedAt": "2023-10-06T20:10:54Z"
  }
]
```

Tested locally that snapshots are received in descending order when specified:

```
curl http://localhost:18000/api/v1/flags/1/snapshots\?limit\=2\&sort\=DESC

[
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kxjfenfcgu4xdcyq1",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-06T16:10:55.490-04:00",
      "variants": []
    },
    "id": 5,
    "updatedAt": "2023-10-06T20:10:55Z"
  },
  {
    "flag": {
      "dataRecordsEnabled": false,
      "description": "test",
      "enabled": false,
      "id": 1,
      "key": "kxjfenfcgu4xdcyq1",
      "segments": [],
      "tags": [],
      "updatedAt": "2023-10-06T16:10:55.080-04:00",
      "variants": []
    },
    "id": 4,
    "updatedAt": "2023-10-06T20:10:55Z"
  }
]
```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.