### PR TITLE
Keep the container image minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN apk add --no-cache git make build-base
 ADD . .
 RUN make build
 
+FROM alpine
+
+COPY --from=go_builder /go/src/github.com/openflagr/flagr/flagr /bin/flagr
+
 ENV HOST=0.0.0.0
 ENV PORT=18000
 ENV FLAGR_DB_DBDRIVER=sqlite3
@@ -32,4 +36,5 @@ USER appuser
 ADD --chown=appuser:appgroup ./buildscripts/demo_sqlite3.db /data/demo_sqlite3.db
 
 EXPOSE 18000
-CMD ./flagr
+
+ENTRYPOINT [ "/bin/flagr" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN make build
 
 FROM alpine
 
-COPY --from=go_builder /go/src/github.com/openflagr/flagr/flagr /bin/flagr
+COPY --from=go_builder /go/src/github.com/openflagr/flagr/flagr .
 
 ENV HOST=0.0.0.0
 ENV PORT=18000
@@ -37,4 +37,4 @@ ADD --chown=appuser:appgroup ./buildscripts/demo_sqlite3.db /data/demo_sqlite3.d
 
 EXPOSE 18000
 
-ENTRYPOINT [ "/bin/flagr" ]
+CMD "./flagr"

--- a/integration_tests/Dockerfile-Integration-Test
+++ b/integration_tests/Dockerfile-Integration-Test
@@ -6,7 +6,7 @@ RUN make build
 
 FROM alpine
 
-COPY --from=go_builder /go/src/github.com/openflagr/flagr/flagr /bin/flagr
+COPY --from=go_builder /go/src/github.com/openflagr/flagr/flagr .
 
 ENV HOST=0.0.0.0
 ENV PORT=18000
@@ -16,4 +16,4 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 EXPOSE 18000
 
-ENTRYPOINT [ "/bin/flagr" ]
+CMD "./flagr"

--- a/integration_tests/Dockerfile-Integration-Test
+++ b/integration_tests/Dockerfile-Integration-Test
@@ -4,6 +4,10 @@ RUN apk add --no-cache git make build-base
 ADD . .
 RUN make build
 
+FROM alpine
+
+COPY --from=go_builder /go/src/github.com/openflagr/flagr/flagr /bin/flagr
+
 ENV HOST=0.0.0.0
 ENV PORT=18000
 ENV FLAGR_DB_DBDRIVER=sqlite3
@@ -11,4 +15,5 @@ ENV FLAGR_RECORDER_ENABLED=false
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 EXPOSE 18000
-CMD ./flagr
+
+ENTRYPOINT [ "/bin/flagr" ]

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3.6"
 
 networks:
   default:
-    external:
-      name: flagr_integration_tests
+    external: true
+    name: flagr_integration_tests
 
 services:
   mysql:


### PR DESCRIPTION
## Description
- Changing the base image to be alpine to save on container size
```sh
## Before
 ghcr.io/openflagr/flagr              latest    2c7473a02b44   4 months ago     2GB

## After
flagr                               latest    7474e3e001c1   37 minutes ago   68.1MB
```

## Motivation and Context
- Reducing the container size for faster downloads and better day 1 Experience.

## How Has This Been Tested?
- To be frank, not in big sets, New to flagr, will check on how the github action goes and take necessary steps.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.