### PR TITLE
UI search by key

### DIFF
--- a/browser/flagr-ui/src/components/Flags.vue
+++ b/browser/flagr-ui/src/components/Flags.vue
@@ -184,16 +184,18 @@ export default {
   computed: {
     filteredFlags: function() {
       if (this.searchTerm) {
-        return this.flags.filter(({ id, description, tags }) =>
+        return this.flags.filter(({ id, key, description, tags }) =>
           this.searchTerm
             .split(",")
             .map(term => {
+              const termLowerCase = term.toLowerCase();
               return (
                 id.toString().includes(term) ||
-                description.toLowerCase().includes(term.toLowerCase()) ||
+                key.includes(term) ||
+                description.toLowerCase().includes(termLowerCase) ||
                 tags
                   .map(tag =>
-                    tag.value.toLowerCase().includes(term.toLowerCase())
+                    tag.value.toLowerCase().includes(termLowerCase)
                   )
                   .includes(true)
               );


### PR DESCRIPTION
## Description
Search by key (UI)

## Motivation and Context
When Flagr is additionally used in an isolated environment (local development), the _key_ is used in the code. Accordingly, to quickly gain access to a flag on UI from code, a _key_ is more handy to use. Otherwise code should contain comment with flag _ID_.

## How Has This Been Tested?
Run UI against any environment and paste partially copy of existing _key_, the item should appear in results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.