### PR TITLE
Flag Migrations

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
     - [Debug Console](flagr_debugging.md)
 - Server Configuration
     - [Env](flagr_env.md)
+    - [Migrations](flagr_migrations.md)
 - Client SDKs
     - [Ruby SDK 🔗](https://github.com/openflagr/rbflagr)
     - [Go SDK 🔗](https://github.com/openflagr/goflagr)

--- a/docs/flagr_migrations.md
+++ b/docs/flagr_migrations.md
@@ -1,0 +1,53 @@
+# Migrations
+
+Users can create flag collections as yaml files within a migration directory and run flagr to insert/modify flags. 
+This allows for developers to create flags as deployment assets and allows for migrating flags through various environments whilst keeping keys stable.
+
+Each found flag is upserted into the database. Then the flag has all segments, variants and tags removed then replaced with the new flag properties.
+
+As an example, create a file named `migrations/202403030000.yaml` with the following content:
+```yaml
+---
+# this is a basic flag
+- key: SIMPLE-FLAG-1
+  description: a toggle for just one user
+  enabled: true
+  segments:
+    - description: flag for just for one email test@test.com
+      rank: 0
+      rolloutPercent: 100
+      constraints:
+        - property: email
+          operator: EQ
+          value: '"test@test.com"'
+      distributions:
+        - variantKey: "on"
+          percent: 100
+    - rank: 1
+      rolloutPercent: 100
+      constraints: []
+      distributions:
+        - variantKey: "off"
+          percent: 100
+  variants:
+    - key: "off"
+      attachment: {}
+    - key: "on"
+      attachment: {}
+  entityType: User
+  dataRecordsEnabled: true
+
+```
+
+```shell
+$ flagr -m 
+INFO[0146] 1 new migrations completed (1 total) 
+```
+Once the application is ran, flagr will scan the migration files, insert them into the db and shut down.
+
+### Config
+Location of yaml configs can be set with either argument or env var.
+```
+FLAGR_MIGRATION_PATH=./migrations/ ./flagr -m
+./flagr -m --migrationPath=`pwd`/migrations
+```

--- a/go.mod
+++ b/go.mod
@@ -147,4 +147,5 @@ require (
 	modernc.org/mathutil v1.5.0 // indirect
 	modernc.org/memory v1.5.0 // indirect
 	modernc.org/sqlite v1.23.1 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -714,3 +714,5 @@ modernc.org/strutil v1.1.3/go.mod h1:MEHNA7PdEnEwLvspRMtWTNnp2nnyvMfkimT1NKNAGbw
 modernc.org/tcl v1.15.0/go.mod h1:xRoGotBZ6dU+Zo2tca+2EqVEeMmOUBzHnhIwq4YrVnE=
 modernc.org/token v1.0.1/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/z v1.7.0/go.mod h1:hVdgNMh8ggTuRG1rGU8x+xGRFfiQUIAw0ZqlPy8+HyQ=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/migrations/.schema.json
+++ b/migrations/.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "key": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "segments": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "rank": {
+                "type": "integer"
+              },
+              "rolloutPercent": {
+                "type": "integer"
+              },
+              "constraints": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                      "property": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "property",
+                      "operator",
+                      "value"
+                    ]
+                  }
+              },
+              "distributions": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "variantKey": {
+                        "type": "string"
+                      },
+                      "percent": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "variantKey",
+                      "percent"
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "rank",
+              "rolloutPercent",
+              "distributions"
+            ]
+          }
+      },
+      "variants": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "attachment": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "key"
+            ]
+          }
+      },
+      "entityType": {
+        "type": "string"
+      },
+      "dataRecordsEnabled": {
+        "type": "boolean"
+      },
+      "tags": {
+        "type": "array",
+        "items":
+          {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ]
+          }
+      }
+    },
+    "required": [
+      "key",
+      "description",
+      "enabled"
+    ]
+  }
+}

--- a/pkg/entity/db.go
+++ b/pkg/entity/db.go
@@ -32,6 +32,7 @@ var AutoMigrateTables = []interface{}{
 	Variant{},
 	Tag{},
 	FlagEntityType{},
+	FlagMigration{},
 }
 
 func connectDB() (db *gorm.DB, err error) {

--- a/pkg/entity/flag_migration.go
+++ b/pkg/entity/flag_migration.go
@@ -1,0 +1,9 @@
+package entity
+
+import "gorm.io/gorm"
+
+type FlagMigration struct {
+	gorm.Model
+
+	Name string `gorm:"type:varchar(64);uniqueIndex:idx_flag_migration_name"`
+}

--- a/pkg/handler/flag_migrations.go
+++ b/pkg/handler/flag_migrations.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"github.com/openflagr/flagr/pkg/entity"
+	"github.com/openflagr/flagr/pkg/mapper/entity_restapi/r2e"
+	"github.com/openflagr/flagr/pkg/util"
+	"github.com/openflagr/flagr/swagger_gen/models"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cast"
+	"gorm.io/gorm/clause"
+	"os"
+	"sigs.k8s.io/yaml"
+	"strings"
+)
+
+type FlagMigrationOptions struct {
+	Run  bool   `long:"migrations" short:"m" description:"Run Flag Migrations and Exit"`
+	Path string `long:"migrationPath" description:"Migration files path" env:"FLAGR_MIGRATION_PATH"`
+}
+
+func FlagMigrations(path string) error {
+	return migrateFromDir(path)
+}
+
+func migrateFromDir(dir string) error {
+	tx := getDB()
+	fms := []entity.FlagMigration{}
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		logrus.WithField("err", err).Errorf("cannot read directory for migrations: %v", err)
+		return err
+	}
+
+	completedFiles := make(map[string]bool)
+
+	tx.Find(&fms)
+
+	for _, fm := range fms {
+		completedFiles[fm.Name] = true
+	}
+
+	completed := 0
+	for _, file := range files {
+		filename := file.Name()
+		if strings.HasSuffix(filename, ".yaml") && !completedFiles[filename] {
+			flags, err := readMigrationFile(dir, filename)
+			if err != nil {
+				continue
+			}
+
+			completed = migrateFlags(flags, filename) + completed
+		}
+
+	}
+
+	logrus.Infof("%d new migrations completed", completed)
+	return nil
+}
+
+func migrateFlags(flags []models.Flag, filename string) int {
+	for _, flagModel := range flags {
+		if f, err := migrateFlag(flagModel); err == nil {
+			entity.SaveFlagSnapshot(getDB(), util.SafeUint(f.ID), "migration "+filename)
+		}
+	}
+
+	fm := entity.FlagMigration{Name: filename}
+	getDB().Create(&fm)
+	return 1
+}
+
+func migrateFlag(flagModel models.Flag) (*entity.Flag, error) {
+	flag := &entity.Flag{
+		EntityType:         flagModel.EntityType,
+		Key:                flagModel.Key,
+		Description:        util.SafeString(flagModel.Description),
+		DataRecordsEnabled: cast.ToBool(flagModel.DataRecordsEnabled),
+		Enabled:            cast.ToBool(flagModel.Enabled),
+		Notes:              util.SafeStringWithDefault(flagModel.Notes, ""),
+	}
+
+	tx := getDB()
+
+	//upsert
+	tx.Where(entity.Flag{Key: flagModel.Key}).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		UpdateAll: true,
+	}).Create(&flag)
+
+	tx = entity.PreloadSegmentsVariantsTags(getDB())
+
+	tx.Where(entity.Flag{Key: flagModel.Key}).First(&flag)
+
+	// delete the association
+	deleteTags(flag)
+
+	// delete the entity (keeps associations
+	deleteVariants(flag)
+	deleteSegments(flag)
+
+	addTags(flagModel, flag)
+
+	// used to map variant to distribution
+	variantMap := saveVariants(flagModel, flag)
+
+	saveSegments(flagModel, flag, variantMap)
+
+	return flag, nil
+}
+
+func saveSegments(flagModel models.Flag, flag *entity.Flag, variantMap map[string]int64) {
+	for _, segmentModel := range flagModel.Segments {
+		segment := entity.Segment{
+			Description:    util.SafeString(segmentModel.Description),
+			RolloutPercent: uint(*segmentModel.RolloutPercent),
+			Rank:           uint(*segmentModel.Rank),
+		}
+		// save segment to flag
+		getDB().Model(flag).Association("Segments").Append(&segment)
+		// map distribution to variant
+		for _, distribution := range segmentModel.Distributions {
+			variantId := variantMap[util.SafeString(distribution.VariantKey)]
+			distribution.VariantID = &variantId
+		}
+		segment.Distributions = r2e.MapDistributions(segmentModel.Distributions, segment.ID)
+		segment.Constraints = r2e.MapConstraints(segmentModel.Constraints, segment.ID)
+		getDB().Save(&segment)
+	}
+}
+
+func saveVariants(flagModel models.Flag, flag *entity.Flag) map[string]int64 {
+	variantMap := make(map[string]int64)
+
+	// add variants
+	for _, variantModel := range flagModel.Variants {
+		a, _ := r2e.MapAttachment(variantModel.Attachment)
+		variant := entity.Variant{
+			Key:        util.SafeString(variantModel.Key),
+			Attachment: a,
+		}
+		getDB().Model(flag).Association("Variants").Append(&variant)
+		variantMap[util.SafeString(variant.Key)] = int64(variant.ID)
+	}
+	return variantMap
+}
+
+func addTags(flagModel models.Flag, flag *entity.Flag) {
+	// add tags
+	for _, tagModel := range flagModel.Tags {
+		t := &entity.Tag{}
+		t.Value = util.SafeString(tagModel.Value)
+		getDB().Where("value = ?", util.SafeString(tagModel.Value)).Find(t)
+		getDB().Model(flag).Association("Tags").Append(t)
+	}
+}
+
+func deleteSegments(flag *entity.Flag) {
+	for _, segmentsModel := range flag.Segments {
+		getDB().Select("Constraints", "Distributions").Delete(&entity.Segment{}, segmentsModel.ID)
+	}
+}
+
+func deleteVariants(flag *entity.Flag) {
+	for _, variantsModel := range flag.Variants {
+		v := &entity.Variant{}
+		v.ID = variantsModel.ID
+		getDB().Delete(&entity.Variant{}, variantsModel.ID)
+	}
+}
+
+func deleteTags(flag *entity.Flag) {
+	for _, tagsModel := range flag.Tags {
+		t := &entity.Tag{}
+		t.ID = uint(tagsModel.ID)
+		getDB().Model(flag).Association("Tags").Delete(t)
+	}
+}
+
+func readMigrationFile(dir string, fileName string) ([]models.Flag, error) {
+	f := dir + string(os.PathSeparator) + fileName
+	contents, err := os.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var flags []models.Flag
+	err = yaml.Unmarshal([]byte(contents), &flags)
+	if err != nil {
+		return nil, err
+	}
+	return flags, nil
+}

--- a/pkg/handler/flag_migrations_test.go
+++ b/pkg/handler/flag_migrations_test.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"github.com/openflagr/flagr/pkg/entity"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFlagMigrations(t *testing.T) {
+	db := entity.NewTestDB()
+
+	tmpDB, dbErr := db.DB()
+	if dbErr != nil {
+		t.Errorf("Failed to get database")
+	}
+
+	defer tmpDB.Close()
+
+	defer gostub.StubFunc(&getDB, db).Reset()
+
+	t.Run("FlagMigrationWithValidPath", func(t *testing.T) {
+		err := FlagMigrations("./testdata/migrations")
+		assert.Nil(t, err)
+	})
+
+	t.Run("FlagMigrationWithInvalidPath", func(t *testing.T) {
+		err := FlagMigrations("./testdata/migration")
+		assert.NotNil(t, err)
+	})
+}

--- a/pkg/handler/testdata/migrations/test-migration-broken.yaml
+++ b/pkg/handler/testdata/migrations/test-migration-broken.yaml
@@ -1,0 +1,7 @@
+---
+# this is a broken yaml since enabled should be a boolean
+- key: FLAG-111
+  description: basic flag
+  entityType: User
+  dataRecordsEnabled: false
+  enabled: 9

--- a/pkg/handler/testdata/migrations/test-migration.yaml
+++ b/pkg/handler/testdata/migrations/test-migration.yaml
@@ -1,0 +1,43 @@
+---
+# this is a basic
+- key: FLAGS-123
+  description: a flag added by migration
+  segments:
+    - description: just email
+      rank: 0
+      rolloutPercent: 100
+      constraints:
+        - property: email
+          operator: EQ
+          value: '"me@me.com"'
+      distributions:
+        - variantKey: "on"
+          percent: 100
+    - rank: 1
+      rolloutPercent: 100
+      distributions:
+        - variantKey: "off"
+          percent: 100
+  variants:
+    - key: "off"
+    - key: "on"
+  entityType: User
+  dataRecordsEnabled: true
+  enabled: false
+  tags:
+    - value: "better tags"
+- key: FLAGS-123
+  description: updated second time
+  segments:
+    - rank: 1
+      rolloutPercent: 100
+      distributions:
+        - variantKey: "off"
+          percent: 100
+  variants:
+    - key: "off"
+  entityType: User
+  dataRecordsEnabled: false
+  enabled: true
+  tags:
+    - value: "best tag"

--- a/pkg/mapper/entity_restapi/r2e/r2e.go
+++ b/pkg/mapper/entity_restapi/r2e/r2e.go
@@ -29,6 +29,25 @@ func MapDistribution(r *models.Distribution, segmentID uint) entity.Distribution
 	return e
 }
 
+func MapConstraints(r []*models.Constraint, segmentID uint) []entity.Constraint {
+	e := make([]entity.Constraint, len(r))
+	for i, d := range r {
+		e[i] = MapConstraint(d, segmentID)
+	}
+	return e
+}
+
+// MapDistribution maps distribution
+func MapConstraint(r *models.Constraint, segmentID uint) entity.Constraint {
+	e := entity.Constraint{
+		SegmentID: segmentID,
+		Property:  util.SafeString(r.Property),
+		Operator:  util.SafeString(r.Operator),
+		Value:     util.SafeString(r.Value),
+	}
+	return e
+}
+
 // MapAttachment maps attachment
 func MapAttachment(a interface{}) (entity.Attachment, error) {
 	e := entity.Attachment{}


### PR DESCRIPTION
## Description
Adds cmd line argument to load flag, variants and segments from yaml files

## Motivation and Context
I needed the ability to deploy flags as code, I paired these changes with a CI task that will upload a repository of yaml migration files that are written by developers. This allows us to migrate flags through environments with stable keys and to have the flags/changes peer reviewed.

## How Has This Been Tested?
Tested using sqlite and mysql, on a osx environment. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.