### PR TITLE
Enable constraint properties trimming in UI

### DIFF
--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -863,6 +863,8 @@ export default {
       );
     },
     createConstraint(segment) {
+      segment.newConstraint.property = segment.newConstraint.property.trim();
+      segment.newConstraint.value = segment.newConstraint.value.trim();
       Axios.post(
         `${API_URL}/flags/${this.flagId}/segments/${segment.id}/constraints`,
         segment.newConstraint
@@ -874,6 +876,8 @@ export default {
       }, handleErr.bind(this));
     },
     putConstraint(segment, constraint) {
+      constraint.property = constraint.property.trim();
+      constraint.value = constraint.value.trim();
       Axios.put(
         `${API_URL}/flags/${this.flagId}/segments/${segment.id}/constraints/${constraint.id}`,
         constraint


### PR DESCRIPTION
Constraint's both `property` and `value` are now trimmed before save from Flagr UI

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Vue's `.trim` input-modifier could be suboptimal from the UX perspective, as you won't be able to input spaces in several cases, e.g. `"some string value"` or `["foo", "bar", "baz"]` (when you type them from left to right)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/openflagr/flagr/issues/599

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make start` on local machine:
- `Add Constraint` trims `segment.newConstraint`'s `property` and `value` in-place before POST;
- `Save` trims existing `constraint`'s `property` and `value` in-place before PUT.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.