### PR TITLE
Do not load Flag History until the History Tab has been clicked

### DIFF
--- a/browser/flagr-ui/src/components/Flag.vue
+++ b/browser/flagr-ui/src/components/Flag.vue
@@ -76,7 +76,7 @@
         </el-breadcrumb>
 
         <div v-if="loaded && flag">
-          <el-tabs>
+          <el-tabs @tab-click="handleHistoryTabClick">
             <el-tab-pane label="Config">
               <el-card class="flag-config-card">
                 <div slot="header" class="el-card-header">
@@ -547,7 +547,7 @@
             </el-tab-pane>
 
             <el-tab-pane label="History">
-              <flag-history :flag-id="parseInt($route.params.flagId, 10)"></flag-history>
+              <flag-history v-if="historyLoaded" :flag-id="parseInt($route.params.flagId, 10)"></flag-history>
             </el-tab-pane>
           </el-tabs>
         </div>
@@ -656,7 +656,8 @@ export default {
       newDistributions: {},
       operatorOptions: operators,
       operatorValueToLabelMap: OPERATOR_VALUE_TO_LABEL_MAP,
-      showMdEditor: false
+      showMdEditor: false,
+      historyLoaded: false
     };
   },
   computed: {
@@ -980,6 +981,11 @@ export default {
     },
     toggleShowMdEditor() {
       this.showMdEditor = !this.showMdEditor;
+    },
+    handleHistoryTabClick(tab) {
+      if (tab.label == "History" && !this.historyLoaded) {
+        this.historyLoaded = true;
+      }
     }
   },
   mounted() {


### PR DESCRIPTION
Update Flag page to not load History until the history tab has been clicked

<!--- Provide a general summary of your changes in the Title above -->

## Description
This Pull Request Update's flagr-ui to not load a Flag's history until a user has shown intent on viewing that information.

## Motivation and Context
When used for configuration management for test flags that are long lived, there can be a large amount of changes made to a flag.  The amount of those changes can add up drastically over time in an enterprise setting.  As the history of a flag grows, the initial page load of a flag takes an exceptionally long time, making the page frustrating or nearly unusable.
Next steps to continue to improve usability of the History page would be to paginate the History results, further decreasing load/wait times.

## How Has This Been Tested?
This change has been tested on my local machine.  The browser application was tested and run locally to ensure that it built.  It was integrated with the backend also running on my local machine via Docker to ensure that a flag's history was not loaded until the appropriate tab was selected.  All UI pages and sections loaded successfully with the test data provided as well as the ability to continue to create/update segments and have those changes reflected in the history tab.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.