### PR TITLE
include flagTags in postEvaluation and postEvaluationBatch

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1353,6 +1353,12 @@ definitions:
       flagSnapshotID:
         type: integer
         format: int64
+      flagTags:
+        description: flagTags. flagTags looks up flags by tag. Either works.
+        type: array
+        x-omitempty: true
+        items:
+          type: string
       segmentID:
         type: integer
         format: int64

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -7,6 +7,7 @@ networks:
 
 services:
   mysql:
+    platform: linux/x86_64
     image: mysql:5.6
     container_name: flagr-mysql
     environment:

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -349,6 +349,7 @@ step_11_test_tag_batch_evaluation() {
     matches "\"flagID\":1"
     matches "\"variantKey\":\"key_1\""
     matches "\"variantID\":1"
+    contains "flagTags"
 
 }
 
@@ -361,12 +362,14 @@ step_12_test_tag_operator_batch_evaluation() {
     matches "\"flagID\":1"
     matches "\"variantKey\":\"key_1\""
     matches "\"variantID\":1"
+    contains "flagTags"
 
     shakedown POST "$flagr_url"/evaluation/batch -H 'Content-Type:application/json' -d '{"entities":[{ "entityType": "externalalert", "entityContext": {"property_1": "value_2"} }],"flagTags": ["value_1", "value_3"], "flagTagsOperator": "ANY", "enableDebug": false }'
     status 200
     matches "\"flagID\":1"
     matches "\"variantKey\":\"key_1\""
     matches "\"variantID\":1"
+    contains "flagTags"
 
 }
 

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -105,10 +105,16 @@ func BlankResult(f *entity.Flag, evalContext models.EvalContext, msg string) *mo
 	flagID := uint(0)
 	flagKey := ""
 	flagSnapshotID := uint(0)
+	flagTags := []string{}
 	if f != nil {
 		flagID = f.ID
 		flagSnapshotID = f.SnapshotID
 		flagKey = f.Key
+		if len(f.Tags) > 0 {
+			for _, tag := range f.Tags {
+				flagTags = append(flagTags, tag.Value)
+			}
+		}
 	}
 	return &models.EvalResult{
 		EvalContext: &evalContext,
@@ -119,6 +125,7 @@ func BlankResult(f *entity.Flag, evalContext models.EvalContext, msg string) *mo
 		FlagID:         int64(flagID),
 		FlagKey:        flagKey,
 		FlagSnapshotID: int64(flagSnapshotID),
+		FlagTags:       flagTags,
 		Timestamp:      util.TimeNow(),
 	}
 }

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -488,6 +488,7 @@ func TestPostEvaluation(t *testing.T) {
 				EntityID:      "entityID1",
 				EntityType:    "entityType1",
 				FlagID:        int64(100),
+				FlagTags:      []string{"tag1", "tag2"},
 			},
 		})
 		assert.NotNil(t, resp)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -488,7 +488,6 @@ func TestPostEvaluation(t *testing.T) {
 				EntityID:      "entityID1",
 				EntityType:    "entityType1",
 				FlagID:        int64(100),
-				FlagTags:      []string{"tag1", "tag2"},
 			},
 		})
 		assert.NotNil(t, resp)

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -167,6 +167,10 @@ func TestEvalFlag(t *testing.T) {
 		})
 		assert.NotNil(t, result)
 		assert.NotZero(t, result.VariantID)
+		assert.NotEmpty(t, result.FlagTags)
+		assert.Len(t, result.FlagTags, 2)
+		assert.Contains(t, result.FlagTags, "tag1")
+		assert.Contains(t, result.FlagTags, "tag2")
 	})
 
 	t.Run("test happy code path with flagKey", func(t *testing.T) {
@@ -467,6 +471,10 @@ func TestEvalFlagsByTags(t *testing.T) {
 		})
 		assert.NotZero(t, len(results))
 		assert.NotZero(t, results[0].VariantID)
+		assert.NotEmpty(t, results[0].FlagTags)
+		assert.Len(t, results[0].FlagTags, 2)
+		assert.Contains(t, results[0].FlagTags, "tag1")
+		assert.Contains(t, results[0].FlagTags, "tag2")
 	})
 }
 
@@ -515,6 +523,7 @@ func TestPostEvaluationBatch(t *testing.T) {
 		assert.NotNil(t, resp)
 	})
 }
+
 func TestTagsPostEvaluationBatch(t *testing.T) {
 	t.Run("test happy code path", func(t *testing.T) {
 		defer gostub.StubFunc(&EvalFlag, &models.EvalResult{}).Reset()

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -481,6 +481,12 @@ definitions:
       flagSnapshotID:
         type: integer
         format: int64
+      flagTags:
+        description: flagTags. flagTags looks up flags by tag. Either works.
+        type: array
+        x-omitempty: true
+        items:
+          type: string
       segmentID:
         type: integer
         format: int64

--- a/swagger_gen/models/eval_result.go
+++ b/swagger_gen/models/eval_result.go
@@ -33,6 +33,9 @@ type EvalResult struct {
 	// flag snapshot ID
 	FlagSnapshotID int64 `json:"flagSnapshotID,omitempty"`
 
+	// flagTags. flagTags looks up flags by tag. Either works.
+	FlagTags []string `json:"flagTags,omitempty"`
+
 	// segment ID
 	SegmentID int64 `json:"segmentID,omitempty"`
 

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1639,6 +1639,14 @@ func init() {
           "type": "integer",
           "format": "int64"
         },
+        "flagTags": {
+          "description": "flagTags. flagTags looks up flags by tag. Either works.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-omitempty": true
+        },
         "segmentID": {
           "type": "integer",
           "format": "int64"
@@ -3729,6 +3737,14 @@ func init() {
         "flagSnapshotID": {
           "type": "integer",
           "format": "int64"
+        },
+        "flagTags": {
+          "description": "flagTags. flagTags looks up flags by tag. Either works.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-omitempty": true
         },
         "segmentID": {
           "type": "integer",


### PR DESCRIPTION
## Motivation and Context
We require the `flagTags` field that includes **all** tags related to a particular flag in the response for our internal logic.

## How Has This Been Tested?
- Added validation checks in `step_11_test_tag_batch_evaluation` to ensure batch evaluations return:
  - `flagTags` field presence
- Added validation checks in `step_12_test_tag_operator_batch_evaluation` to ensure:
  - `flagTags` field presence

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) ?? maybe not exactly a bug-fix

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.