### PR TITLE
refactor: modernize Attachment type to use any

### DIFF
--- a/pkg/entity/variant.go
+++ b/pkg/entity/variant.go
@@ -29,10 +29,10 @@ func (v *Variant) Validate() error {
 }
 
 // Attachment supports dynamic configuration in variant
-type Attachment map[string]interface{}
+type Attachment map[string]any
 
 // Scan implements scanner interface
-func (a *Attachment) Scan(value interface{}) error {
+func (a *Attachment) Scan(value any) error {
 	if value == nil {
 		return nil
 	}
@@ -50,4 +50,29 @@ func (a Attachment) Value() (driver.Value, error) {
 		return nil, err
 	}
 	return string(bytes), nil
+}
+
+// Get returns the value of the key
+func (a Attachment) Get(key string) any {
+	return a[key]
+}
+
+// GetString returns the string value of the key
+func (a Attachment) GetString(key string) string {
+	return cast.ToString(a[key])
+}
+
+// GetInt returns the int value of the key
+func (a Attachment) GetInt(key string) int {
+	return cast.ToInt(a[key])
+}
+
+// GetBool returns the bool value of the key
+func (a Attachment) GetBool(key string) bool {
+	return cast.ToBool(a[key])
+}
+
+// GetFloat64 returns the float64 value of the key
+func (a Attachment) GetFloat64(key string) float64 {
+	return cast.ToFloat64(a[key])
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -68,9 +68,9 @@ func NewSecureRandomKey() string {
 	return randomKeyPrefix + uniuri.NewLenChars(uniuri.StdLen, randomKeyCharset)
 }
 
-// SafeStringWithDefault parse an interface to string
+// SafeStringWithDefault parse an any to string
 // and set it to default value if it's empty
-func SafeStringWithDefault(s interface{}, deft string) (ret string) {
+func SafeStringWithDefault(s any, deft string) (ret string) {
 	ret = SafeString(s)
 	if ret == "" {
 		ret = deft
@@ -79,12 +79,12 @@ func SafeStringWithDefault(s interface{}, deft string) (ret string) {
 }
 
 // SafeString safely cast to string
-func SafeString(s interface{}) (ret string) {
+func SafeString(s any) (ret string) {
 	return cast.ToString(s)
 }
 
 // SafeUint returns the uint of the value
-func SafeUint(s interface{}) (ret uint) {
+func SafeUint(s any) (ret uint) {
 	return cast.ToUint(s)
 }
 


### PR DESCRIPTION
# Modernization of Attachment Type

I have modernized the `Attachment` type and related utility functions to use `any` instead of `interface{}`. Additionally, I've added helper methods to the `Attachment` type to improve usability and provide a more "type-safe" experience when interacting with dynamic configuration.

## Changes Made

### Modernization to `any`

I replaced `interface{}` with `any` in the following files:
- [variant.go](file:///Users/rex/Dev/flagr/pkg/entity/variant.go)
- [util.go](file:///Users/rex/Dev/flagr/pkg/util/util.go)

### Helper Methods for `Attachment`

I added the following methods to `Attachment` in [variant.go](file:///Users/rex/Dev/flagr/pkg/entity/variant.go):
- `Get(key string) any`
- `GetString(key string) string`
- `GetInt(key string) int`
- `GetBool(key string) bool`
- `GetFloat64(key string) float64`

These methods use `github.com/spf13/cast` for safe type conversions, reducing the need for manual type assertions in the codebase.

## Verification Results

### Automated Tests

All tests passed successfully for `pkg/entity`, `pkg/util`, and `pkg/handler`.

```
ok      github.com/openflagr/flagr/pkg/entity   2.056s
ok      github.com/openflagr/flagr/pkg/util     1.082s
ok      github.com/openflagr/flagr/pkg/handler  13.895s
```

The modernization has been verified to be backward compatible and maintains all existing functionality.
