### PR TITLE
Extend EvalCache export with a querying option

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -961,6 +961,50 @@ paths:
       description: Export JSON format of the eval cache dump
       produces:
         - application/json
+      parameters:
+        - in: query
+          name: ids
+          description: >-
+            "query optimized" flagIDs parameter. Has precedence over `enabled`,
+            `keys` and `tags` parameters.
+          required: false
+          type: array
+          collectionFormat: csv
+          minItems: 1
+          items:
+            type: integer
+            format: int64
+            minimum: 1
+        - in: query
+          name: keys
+          description: >-
+            "query optimized" flagKeys parameter. Has precedence over `enabled`
+            and `tags` parameter.
+          required: false
+          type: array
+          items:
+            type: string
+            minLength: 1
+        - in: query
+          name: enabled
+          description: return flags having given enabled status
+          required: false
+          type: boolean
+        - in: query
+          name: tags
+          description: '"query optimized" flagTags parameter'
+          required: false
+          type: array
+          items:
+            type: string
+            minLength: 1
+        - in: query
+          name: all
+          type: boolean
+          description: >-
+            whether to use ALL (tags) semantics (ANY by default):
+            `?tags=foo,bar&all=true` is equivalent to postEvaluation's
+            `flagTagsOperator: "ALL"`
       responses:
         '200':
           description: OK

--- a/pkg/entity/fixture.go
+++ b/pkg/entity/fixture.go
@@ -42,6 +42,20 @@ func GenFixtureFlag() Flag {
 	return f
 }
 
+func GenFixtureFlagWithTags(id uint, key string, enabled bool, tags []string) Flag {
+	f := Flag{
+		Model:       gorm.Model{ID: id},
+		Key:         key,
+		Description: "",
+		Enabled:     enabled,
+		Tags:        []Tag{},
+	}
+	for _, tag := range tags {
+		f.Tags = append(f.Tags, Tag{Value: tag})
+	}
+	return f
+}
+
 // GenFixtureSegment is a fixture
 func GenFixtureSegment() Segment {
 	s := Segment{

--- a/pkg/handler/eval_cache_test.go
+++ b/pkg/handler/eval_cache_test.go
@@ -1,8 +1,11 @@
 package handler
 
 import (
-	"github.com/openflagr/flagr/swagger_gen/models"
+	"slices"
 	"testing"
+
+	"github.com/openflagr/flagr/swagger_gen/models"
+	"github.com/openflagr/flagr/swagger_gen/restapi/operations/export"
 
 	"github.com/openflagr/flagr/pkg/entity"
 
@@ -70,4 +73,109 @@ func TestGetByTags(t *testing.T) {
 
 	f = ec.GetByTags(tags, &all)
 	assert.Len(t, f, 0)
+}
+
+func TestEvalCacheExport(t *testing.T) {
+	ec := GenFixtureEvalCacheWithFlags([]entity.Flag{
+		entity.GenFixtureFlagWithTags(1, "first", true, []string{"tag1", "tag2"}),
+		entity.GenFixtureFlagWithTags(2, "second", true, []string{"tag2", "tag3"}),
+		entity.GenFixtureFlagWithTags(3, "third", false, []string{"tag2", "tag3"}),
+		entity.GenFixtureFlagWithTags(4, "fourth", true, []string{}),
+	})
+
+	t.Run("should be able to query cache via flag ids", func(t *testing.T) {
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Ids: []int64{1, 3}}).Flags
+		assert.Len(t, exportedFlags, 2)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(3)))
+	})
+
+	t.Run("should be able to query cache via flag keys", func(t *testing.T) {
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Keys: []string{"second", "fourth"}}).Flags
+		assert.Len(t, exportedFlags, 2)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(2)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+	})
+
+	t.Run("should be able to query cache via enabled property", func(t *testing.T) {
+		tru := true
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Enabled: &tru}).Flags
+		assert.Len(t, exportedFlags, 3)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(2)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+
+		fals := false
+		exportedFlags = ec.export(export.GetExportEvalCacheJSONParams{Enabled: &fals}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(3)))
+	})
+
+	t.Run("should be able to query cache via tags with default ANY semantics", func(t *testing.T) {
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Tags: []string{"tag1", "tag2"}}).Flags
+		assert.Len(t, exportedFlags, 3)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(2)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(3)))
+
+		fals := false
+		exportedFlags = ec.export(export.GetExportEvalCacheJSONParams{All: &fals, Tags: []string{"tag1", "tag2"}}).Flags
+		assert.Len(t, exportedFlags, 3)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(2)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(3)))
+	})
+
+	t.Run("should be able to query cache via tags with ALL semantics", func(t *testing.T) {
+		tru := true
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{All: &tru, Tags: []string{"tag1", "tag2"}}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+	})
+
+	t.Run("flag ids query should have precedence over other queries", func(t *testing.T) {
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Ids: []int64{4}, Keys: []string{"first", "second"}}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+
+		fals := false
+		exportedFlags = ec.export(export.GetExportEvalCacheJSONParams{Ids: []int64{4}, Enabled: &fals}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+
+		exportedFlags = ec.export(export.GetExportEvalCacheJSONParams{Ids: []int64{4}, Tags: []string{"tag1"}}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+	})
+
+	t.Run("flag keys query should have precedence over enabled and tags queries", func(t *testing.T) {
+		fals := false
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Keys: []string{"fourth"}, Enabled: &fals}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+
+		exportedFlags = ec.export(export.GetExportEvalCacheJSONParams{Keys: []string{"fourth"}, Tags: []string{"tag1"}}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(4)))
+	})
+
+	t.Run("should be able to combine enabled and tags queries", func(t *testing.T) {
+		tru := true
+		exportedFlags := ec.export(export.GetExportEvalCacheJSONParams{Enabled: &tru, Tags: []string{"tag2"}}).Flags
+		assert.Len(t, exportedFlags, 2)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(1)))
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(2)))
+
+		fals := false
+		exportedFlags = ec.export(export.GetExportEvalCacheJSONParams{Enabled: &fals, Tags: []string{"tag2"}}).Flags
+		assert.Len(t, exportedFlags, 1)
+		assert.True(t, slices.ContainsFunc(exportedFlags, withID(3)))
+	})
+}
+
+func withID(id uint) func(entity.Flag) bool {
+	return func(f entity.Flag) bool {
+		return f.ID == id
+	}
 }

--- a/pkg/handler/export.go
+++ b/pkg/handler/export.go
@@ -100,8 +100,8 @@ var exportFlagEntityTypes = func(tmpDB *gorm.DB) error {
 	return nil
 }
 
-var exportEvalCacheJSONHandler = func(export.GetExportEvalCacheJSONParams) middleware.Responder {
+var exportEvalCacheJSONHandler = func(query export.GetExportEvalCacheJSONParams) middleware.Responder {
 	return export.NewGetExportEvalCacheJSONOK().WithPayload(
-		GetEvalCache().export(),
+		GetEvalCache().export(query),
 	)
 }

--- a/pkg/handler/fixture.go
+++ b/pkg/handler/fixture.go
@@ -24,3 +24,29 @@ func GenFixtureEvalCache() *EvalCache {
 
 	return ec
 }
+
+func GenFixtureEvalCacheWithFlags(flags []entity.Flag) *EvalCache {
+	idCache := make(map[string]*entity.Flag)
+	keyCache := make(map[string]*entity.Flag)
+	tagCache := make(map[string]map[uint]*entity.Flag)
+	for _, f := range flags {
+		idCache[util.SafeString(f.ID)] = &f
+		keyCache[f.Key] = &f
+		for _, tag := range f.Tags {
+			if tagCache[tag.Value] == nil {
+				tagCache[tag.Value] = make(map[uint]*entity.Flag)
+			}
+			tagCache[tag.Value][f.ID] = &f
+		}
+	}
+
+	ec := &EvalCache{
+		cache: &cacheContainer{
+			idCache:  idCache,
+			keyCache: keyCache,
+			tagCache: tagCache,
+		},
+	}
+
+	return ec
+}

--- a/swagger/export_eval_cache_json.yaml
+++ b/swagger/export_eval_cache_json.yaml
@@ -5,6 +5,52 @@ get:
   description: Export JSON format of the eval cache dump
   produces:
     - application/json
+  parameters:
+    - in: query
+      name: ids
+      description: >-
+        "query optimized" flagIDs parameter.
+        Has precedence over `enabled`, `keys` and `tags` parameters.
+      required: false
+      type: array
+      collectionFormat: csv
+      minItems: 1
+      items:
+        type: integer
+        format: int64
+        minimum: 1
+    - in: query
+      name: keys
+      description: >-
+        "query optimized" flagKeys parameter.
+        Has precedence over `enabled` and `tags` parameter.
+      required: false
+      type: array
+      items:
+        type: string
+        minLength: 1
+    - in: query
+      name: enabled
+      description: >-
+        return flags having given enabled status
+      required: false
+      type: boolean
+    - in: query
+      name: tags
+      description: >-
+        "query optimized" flagTags parameter
+      required: false
+      type: array
+      items:
+        type: string
+        minLength: 1
+    - in: query
+      name: all
+      type: boolean
+      description: >-
+        whether to use ALL (tags) semantics (ANY by default):
+        `?tags=foo,bar&all=true` is equivalent to postEvaluation's
+        `flagTagsOperator: "ALL"`
   responses:
     200:
       description: OK

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -111,6 +111,53 @@ func init() {
           "export"
         ],
         "operationId": "getExportEvalCacheJSON",
+        "parameters": [
+          {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "minimum": 1,
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv",
+            "description": "\"query optimized\" flagIDs parameter. Has precedence over ` + "`" + `enabled` + "`" + `, ` + "`" + `keys` + "`" + ` and ` + "`" + `tags` + "`" + ` parameters.",
+            "name": "ids",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": "\"query optimized\" flagKeys parameter. Has precedence over ` + "`" + `enabled` + "`" + ` and ` + "`" + `tags` + "`" + ` parameter.",
+            "name": "keys",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "return flags having given enabled status",
+            "name": "enabled",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": "\"query optimized\" flagTags parameter",
+            "name": "tags",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "whether to use ALL (tags) semantics (ANY by default): ` + "`" + `?tags=foo,bar\u0026all=true` + "`" + ` is equivalent to postEvaluation's ` + "`" + `flagTagsOperator: \"ALL\"` + "`" + `",
+            "name": "all",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2208,6 +2255,53 @@ func init() {
           "export"
         ],
         "operationId": "getExportEvalCacheJSON",
+        "parameters": [
+          {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "minimum": 1,
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv",
+            "description": "\"query optimized\" flagIDs parameter. Has precedence over ` + "`" + `enabled` + "`" + `, ` + "`" + `keys` + "`" + ` and ` + "`" + `tags` + "`" + ` parameters.",
+            "name": "ids",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": "\"query optimized\" flagKeys parameter. Has precedence over ` + "`" + `enabled` + "`" + ` and ` + "`" + `tags` + "`" + ` parameter.",
+            "name": "keys",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "return flags having given enabled status",
+            "name": "enabled",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "description": "\"query optimized\" flagTags parameter",
+            "name": "tags",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "whether to use ALL (tags) semantics (ANY by default): ` + "`" + `?tags=foo,bar\u0026all=true` + "`" + ` is equivalent to postEvaluation's ` + "`" + `flagTagsOperator: \"ALL\"` + "`" + `",
+            "name": "all",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",

--- a/swagger_gen/restapi/operations/export/get_export_eval_cache_json_urlbuilder.go
+++ b/swagger_gen/restapi/operations/export/get_export_eval_cache_json_urlbuilder.go
@@ -9,11 +9,21 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+
+	"github.com/go-openapi/swag"
 )
 
 // GetExportEvalCacheJSONURL generates an URL for the get export eval cache JSON operation
 type GetExportEvalCacheJSONURL struct {
+	All     *bool
+	Enabled *bool
+	Ids     []int64
+	Keys    []string
+	Tags    []string
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -42,6 +52,77 @@ func (o *GetExportEvalCacheJSONURL) Build() (*url.URL, error) {
 		_basePath = "/api/v1"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var allQ string
+	if o.All != nil {
+		allQ = swag.FormatBool(*o.All)
+	}
+	if allQ != "" {
+		qs.Set("all", allQ)
+	}
+
+	var enabledQ string
+	if o.Enabled != nil {
+		enabledQ = swag.FormatBool(*o.Enabled)
+	}
+	if enabledQ != "" {
+		qs.Set("enabled", enabledQ)
+	}
+
+	var idsIR []string
+	for _, idsI := range o.Ids {
+		idsIS := swag.FormatInt64(idsI)
+		if idsIS != "" {
+			idsIR = append(idsIR, idsIS)
+		}
+	}
+
+	ids := swag.JoinByFormat(idsIR, "csv")
+
+	if len(ids) > 0 {
+		qsv := ids[0]
+		if qsv != "" {
+			qs.Set("ids", qsv)
+		}
+	}
+
+	var keysIR []string
+	for _, keysI := range o.Keys {
+		keysIS := keysI
+		if keysIS != "" {
+			keysIR = append(keysIR, keysIS)
+		}
+	}
+
+	keys := swag.JoinByFormat(keysIR, "")
+
+	if len(keys) > 0 {
+		qsv := keys[0]
+		if qsv != "" {
+			qs.Set("keys", qsv)
+		}
+	}
+
+	var tagsIR []string
+	for _, tagsI := range o.Tags {
+		tagsIS := tagsI
+		if tagsIS != "" {
+			tagsIR = append(tagsIR, tagsIS)
+		}
+	}
+
+	tags := swag.JoinByFormat(tagsIR, "")
+
+	if len(tags) > 0 {
+		qsv := tags[0]
+		if qsv != "" {
+			qs.Set("tags", qsv)
+		}
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a querying option to EvalCache export function in a https://github.com/openflagr/flagr/pull/616 way:

- `ids` — csv of flag ids (highest precedence)
- `keys` — csv of flag keys (second precedence)
- `enabled` — queries flags with a given enabled status (could be combined with `tags` and `all`)
- `tags` — csv of flag tags to query (could be combined with `enabled` and `all`)
- `all` — whether to use `ALL` or `ANY` semantics over provided `tags` (`ANY` by default, could be combined with `enabled` and `tags`)

For example:
- `GET /api/v1/export/eval_cache/json?tags=foo,bar&all=true` to get only flags containing both `foo` and `bar` tags
- `GET /api/v1/export/eval_cache/json?tags=foo&enabled=true` to get only _enabled_ flags containing `foo` tag
- `GET /api/v1/export/eval_cache/json?ids=1,2` to get only flags of id `1` and `2`
- `GET /api/v1/export/eval_cache/json?keys=one,two` to get only flags of keys `one` and `two`
- `GET /api/v1/export/eval_cache/json?keys=one&tags=foo` is equivalent to `GET /api/v1/export/eval_cache/json?keys=one` (`tags=foo` effectively would be omitted)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/openflagr/flagr/issues/628

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

That is a new export functionality, so new tests/specs were added (`TestEvalCacheExport`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.