### PR TITLE
Fix DoS vulnerability in batch evaluation endpoint

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -47,6 +47,11 @@ var Config = struct {
 	// This is calculated as: len(entities) * (len(flagIDs) + len(flagKeys) + estimated_flags_from_tags).
 	// Set to 0 to disable the limit (default). Enable this for additional DoS protection.
 	// Note: Duplicate flagKeys and flagIDs are always deduplicated regardless of this setting.
+	//
+	// Example calculation for 10k flags:
+	// - With 2 entities and 10 flagIDs + 10 flagKeys: 2 * (10 + 10) = 40 evaluations
+	// - With 2 entities and 2 tags (~100 flags each): 2 * 100 = 200 evaluations
+	// A reasonable limit might be 500-1000 for typical use cases.
 	EvalBatchSize int `env:"FLAGR_EVAL_BATCH_SIZE" envDefault:"0"`
 
 	/**

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -43,6 +43,12 @@ var Config = struct {
 	// This field will be derived from DBDriver
 	EvalOnlyMode bool `env:"FLAGR_EVAL_ONLY_MODE" envDefault:"false"`
 
+	// EvalBatchSize - maximum number of total evaluations allowed in a single batch request.
+	// This is calculated as: len(entities) * (len(flagIDs) + len(flagKeys) + estimated_flags_from_tags).
+	// Set to 0 to disable the limit (default). Enable this for additional DoS protection.
+	// Note: Duplicate flagKeys and flagIDs are always deduplicated regardless of this setting.
+	EvalBatchSize int `env:"FLAGR_EVAL_BATCH_SIZE" envDefault:"0"`
+
 	/**
 	DBDriver and DBConnectionStr define how we can write and read flags data.
 	For databases, flagr supports sqlite3, mysql and postgres.

--- a/pkg/handler/eval.go
+++ b/pkg/handler/eval.go
@@ -56,12 +56,12 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 	results := &models.EvaluationBatchResponse{}
 
 	// Deduplicate flagKeys to prevent DoS via repeated keys
-	if len(flagKeys) > 0 {
-		seen := make(map[string]bool)
+	if len(flagKeys) > 1 {
+		seen := make(map[string]struct{}, len(flagKeys))
 		uniqueFlagKeys := make([]string, 0, len(flagKeys))
 		for _, k := range flagKeys {
-			if !seen[k] {
-				seen[k] = true
+			if _, exists := seen[k]; !exists {
+				seen[k] = struct{}{}
 				uniqueFlagKeys = append(uniqueFlagKeys, k)
 			}
 		}
@@ -69,12 +69,12 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 	}
 
 	// Deduplicate flagIDs to prevent DoS via repeated IDs
-	if len(flagIDs) > 0 {
-		seen := make(map[int64]bool)
+	if len(flagIDs) > 1 {
+		seen := make(map[int64]struct{}, len(flagIDs))
 		uniqueFlagIDs := make([]int64, 0, len(flagIDs))
 		for _, id := range flagIDs {
-			if !seen[id] {
-				seen[id] = true
+			if _, exists := seen[id]; !exists {
+				seen[id] = struct{}{}
 				uniqueFlagIDs = append(uniqueFlagIDs, id)
 			}
 		}
@@ -82,18 +82,16 @@ func (e *eval) PostEvaluationBatch(params evaluation.PostEvaluationBatchParams) 
 	}
 
 	// Validate batch size to prevent DoS attacks via resource exhaustion (if enabled)
-	maxBatchSize := config.Config.EvalBatchSize
-	if maxBatchSize > 0 {
+	if maxBatchSize := config.Config.EvalBatchSize; maxBatchSize > 0 {
 		// Calculate total evaluations: entities * (flagIDs + flagKeys + flagTags)
 		// For flagTags, we count each tag as potentially matching one flag (conservative estimate)
 		flagsPerEntity := len(flagIDs) + len(flagKeys)
 		if len(flagTags) > 0 {
 			flagsPerEntity++ // flagTags is evaluated once per entity regardless of count
 		}
-		totalEvaluations := len(entities) * flagsPerEntity
-		if totalEvaluations > maxBatchSize {
+		if total := len(entities) * flagsPerEntity; total > maxBatchSize {
 			return evaluation.NewPostEvaluationBatchDefault(400).WithPayload(
-				ErrorMessage("batch evaluation size %d exceeds maximum allowed size of %d", totalEvaluations, maxBatchSize))
+				ErrorMessage("batch evaluation size %d exceeds maximum allowed size of %d", total, maxBatchSize))
 		}
 	}
 


### PR DESCRIPTION
Add deduplication for flagKeys and flagIDs to prevent resource exhaustion attacks via the /api/v1/evaluation/batch endpoint where attackers could send the same key repeated thousands of times.

Also add optional FLAGR_EVAL_BATCH_SIZE limit (default: 0/disabled) for users who want additional protection against large unique key lists.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.