### PR TITLE
chore(deps): upgrade Go from 1.25.2 to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
-      GOEXPERIMENT: greenteagc
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.2
+          go-version: 1.26
       - name: Check out source code
         uses: actions/checkout@v4
       - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,12 @@ RUN make build_ui
 ######################################
 # Prepare go_builder
 ######################################
-FROM golang:1.25.2-alpine as go_builder
+FROM golang:1.26-alpine as go_builder
 WORKDIR /go/src/github.com/openflagr/flagr
 
 RUN apk add --no-cache git make build-base
 ADD . .
 ENV CGO_ENABLED=0
-ENV GOEXPERIMENT=greenteagc
 RUN make build
 
 FROM alpine

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openflagr/flagr
 
-go 1.25.2
+go 1.26
 
 require (
 	cloud.google.com/go v0.123.0 // indirect

--- a/integration_tests/Dockerfile-Integration-Test
+++ b/integration_tests/Dockerfile-Integration-Test
@@ -1,9 +1,8 @@
-FROM golang:1.25.2-alpine as go_builder
+FROM golang:1.26-alpine as go_builder
 WORKDIR /go/src/github.com/openflagr/flagr
 RUN apk add --no-cache git make build-base
 ADD . .
 ENV CGO_ENABLED=0
-ENV GOEXPERIMENT=greenteagc
 RUN make build
 
 FROM alpine


### PR DESCRIPTION
## Summary

Upgrade Go version from 1.25.2 to 1.26.

## Changes

- `go.mod`: go 1.25.2 → go 1.26
- `Dockerfile`: golang:1.25.2-alpine → golang:1.26-alpine, remove GOEXPERIMENT=greenteagc
- `integration_tests/Dockerfile-Integration-Test`: golang:1.25.2-alpine → golang:1.26-alpine, remove GOEXPERIMENT=greenteagc
- `.github/workflows/ci.yml`: go-version: 1.25.2 → go-version: 1.26, remove GOEXPERIMENT=greenteagc

## Verification

- ✅ Tests pass: `go test ./pkg/...`
- ✅ Build succeeds: `go build`
- ✅ Lint passes: `golangci-lint` (no issues)

## Go 1.26 Highlights

- ✅ Green Tea GC is now the default (no longer needs GOEXPERIMENT)
- `new()` function now accepts expressions as operands
- Generic types can self-reference in type parameter lists
- Revamped `go fix` with modernizers for automatic code updates