### PR TITLE
refactor: modernize pointers to go 1.26 syntax

### DIFF
--- a/pkg/handler/crud_flag_creation_test.go
+++ b/pkg/handler/crud_flag_creation_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/openflagr/flagr/pkg/entity"
-	"github.com/openflagr/flagr/pkg/util"
 	"github.com/openflagr/flagr/swagger_gen/models"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/flag"
 	"github.com/prashantv/gostub"
@@ -29,7 +28,7 @@ func TestCrudCreateFlag(t *testing.T) {
 	t.Run("it should be able to create one flag", func(t *testing.T) {
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr("funny flag"),
+				Description: new("funny flag"),
 				Key:         "some_random_flag_key",
 			},
 		})
@@ -45,7 +44,7 @@ func TestCrudCreateFlag(t *testing.T) {
 	t.Run("it should be able to create simple_boolean_flag template", func(t *testing.T) {
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr("simple flag"),
+				Description: new("simple flag"),
 				Key:         "simple_boolean_flag_key",
 				Template:    "simple_boolean_flag",
 			},
@@ -93,7 +92,7 @@ func TestCrudCreateFlagWithFailures(t *testing.T) {
 		defer gostub.StubFunc(&e2rMapFlag, nil, fmt.Errorf("e2r MapFlag error")).Reset()
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr("funny flag"),
+				Description: new("funny flag"),
 			},
 		})
 		assert.NotZero(t, res.(*flag.CreateFlagDefault).Payload)
@@ -103,7 +102,7 @@ func TestCrudCreateFlagWithFailures(t *testing.T) {
 		db.Error = fmt.Errorf("db generic error")
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr("funny flag"),
+				Description: new("funny flag"),
 			},
 		})
 		assert.NotZero(t, res.(*flag.CreateFlagDefault).Payload)
@@ -113,7 +112,7 @@ func TestCrudCreateFlagWithFailures(t *testing.T) {
 	t.Run("CreateFlag - invalid key error", func(t *testing.T) {
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr(" flag with a space"),
+				Description: new(" flag with a space"),
 				Key:         " 1-2-3", // invalid key
 			},
 		})
@@ -123,7 +122,7 @@ func TestCrudCreateFlagWithFailures(t *testing.T) {
 	t.Run("CreateFlag - invalid template error", func(t *testing.T) {
 		res = c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr(" flag with a space"),
+				Description: new(" flag with a space"),
 				Key:         "invalid_template",
 				Template:    "invalid_template",
 			},

--- a/pkg/handler/crud_test.go
+++ b/pkg/handler/crud_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 
 	"github.com/openflagr/flagr/pkg/entity"
-	"github.com/openflagr/flagr/pkg/util"
 	"github.com/openflagr/flagr/swagger_gen/models"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/constraint"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/distribution"
@@ -42,7 +41,7 @@ func TestCrudFlags(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 			Key:         "flag_key_1",
 		},
 	})
@@ -57,12 +56,12 @@ func TestCrudFlags(t *testing.T) {
 		allFlags := len(res.(*flag.FindFlagsOK).Payload)
 
 		res = c.FindFlags(flag.FindFlagsParams{
-			Enabled: util.BoolPtr(true),
+			Enabled: new(true),
 		})
 		enabledFlags := len(res.(*flag.FindFlagsOK).Payload)
 
 		res = c.FindFlags(flag.FindFlagsParams{
-			Enabled: util.BoolPtr(false),
+			Enabled: new(false),
 		})
 		disabledFlags := len(res.(*flag.FindFlagsOK).Payload)
 
@@ -85,20 +84,20 @@ func TestCrudFlags(t *testing.T) {
 		c.CreateSegment(segment.CreateSegmentParams{
 			FlagID: int64(1),
 			Body: &models.CreateSegmentRequest{
-				Description:    util.StringPtr("segment1"),
-				RolloutPercent: util.Int64Ptr(int64(100)),
+				Description:    new("segment1"),
+				RolloutPercent: new(int64(100)),
 			},
 		})
 		c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr("variant1"),
+				Key: new("variant1"),
 			},
 		})
 		c.CreateTag(tag.CreateTagParams{
 			FlagID: int64(1),
 			Body: &models.CreateTagRequest{
-				Value: util.StringPtr("Tag1"),
+				Value: new("Tag1"),
 			},
 		})
 		res = c.GetFlag(flag.GetFlagParams{FlagID: int64(1)})
@@ -111,10 +110,10 @@ func TestCrudFlags(t *testing.T) {
 		res = c.PutFlag(flag.PutFlagParams{
 			FlagID: int64(1),
 			Body: &models.PutFlagRequest{
-				Description:        util.StringPtr("another funny flag"),
-				DataRecordsEnabled: util.BoolPtr(true),
-				Key:                util.StringPtr("flag_key_1"),
-				Notes:              util.StringPtr("# funny flag notes"),
+				Description:        new("another funny flag"),
+				DataRecordsEnabled: new(true),
+				Key:                new("flag_key_1"),
+				Notes:              new("# funny flag notes"),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagOK).Payload.ID)
@@ -127,7 +126,7 @@ func TestCrudFlags(t *testing.T) {
 		res = c.SetFlagEnabledState(flag.SetFlagEnabledParams{
 			FlagID: int64(1),
 			Body: &models.SetFlagEnabledRequest{
-				Enabled: util.BoolPtr(true),
+				Enabled: new(true),
 			}},
 		)
 		assert.True(t, *res.(*flag.SetFlagEnabledOK).Payload.Enabled)
@@ -137,7 +136,7 @@ func TestCrudFlags(t *testing.T) {
 		res = c.PutFlag(flag.PutFlagParams{
 			FlagID: int64(1),
 			Body: &models.PutFlagRequest{
-				EntityType: util.StringPtr("report"),
+				EntityType: new("report"),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagOK).Payload.ID)
@@ -190,7 +189,7 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 	t.Run("GetFlag - got e2r MapFlag error", func(t *testing.T) {
 		c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr("funny flag"),
+				Description: new("funny flag"),
 				Key:         "flag_key_1",
 			},
 		})
@@ -216,8 +215,8 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.PutFlag(flag.PutFlagParams{
 			FlagID: int64(99999),
 			Body: &models.PutFlagRequest{
-				Description:        util.StringPtr("another funny flag"),
-				DataRecordsEnabled: util.BoolPtr(true),
+				Description:        new("another funny flag"),
+				DataRecordsEnabled: new(true),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagDefault).Payload)
@@ -228,8 +227,8 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.PutFlag(flag.PutFlagParams{
 			FlagID: int64(1),
 			Body: &models.PutFlagRequest{
-				Description:        util.StringPtr("another funny flag"),
-				DataRecordsEnabled: util.BoolPtr(true),
+				Description:        new("another funny flag"),
+				DataRecordsEnabled: new(true),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagDefault).Payload)
@@ -240,8 +239,8 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.PutFlag(flag.PutFlagParams{
 			FlagID: int64(1),
 			Body: &models.PutFlagRequest{
-				Description:        util.StringPtr("another funny flag"),
-				DataRecordsEnabled: util.BoolPtr(true),
+				Description:        new("another funny flag"),
+				DataRecordsEnabled: new(true),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagDefault).Payload)
@@ -252,9 +251,9 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.PutFlag(flag.PutFlagParams{
 			FlagID: int64(2),
 			Body: &models.PutFlagRequest{
-				Description:        util.StringPtr("another funny flag"),
-				DataRecordsEnabled: util.BoolPtr(true),
-				Key:                util.StringPtr("flag_key_1"),
+				Description:        new("another funny flag"),
+				DataRecordsEnabled: new(true),
+				Key:                new("flag_key_1"),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.PutFlagDefault).Payload)
@@ -264,7 +263,7 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.SetFlagEnabledState(flag.SetFlagEnabledParams{
 			FlagID: int64(99999),
 			Body: &models.SetFlagEnabledRequest{
-				Enabled: util.BoolPtr(true),
+				Enabled: new(true),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.SetFlagEnabledDefault).Payload)
@@ -275,7 +274,7 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.SetFlagEnabledState(flag.SetFlagEnabledParams{
 			FlagID: int64(1),
 			Body: &models.SetFlagEnabledRequest{
-				Enabled: util.BoolPtr(true),
+				Enabled: new(true),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.SetFlagEnabledDefault).Payload)
@@ -286,7 +285,7 @@ func TestCrudFlagsWithFailures(t *testing.T) {
 		res = c.SetFlagEnabledState(flag.SetFlagEnabledParams{
 			FlagID: int64(1),
 			Body: &models.SetFlagEnabledRequest{
-				Enabled: util.BoolPtr(true),
+				Enabled: new(true),
 			}},
 		)
 		assert.NotZero(t, res.(*flag.SetFlagEnabledDefault).Payload)
@@ -328,10 +327,10 @@ func TestFindFlags(t *testing.T) {
 	defer tmpDB.Close()
 	defer gostub.StubFunc(&getDB, db).Reset()
 
-	for i := 0; i < numOfFlags; i++ {
+	for i := range numOfFlags {
 		c.CreateFlag(flag.CreateFlagParams{
 			Body: &models.CreateFlagRequest{
-				Description: util.StringPtr(fmt.Sprintf("flag_%d", i)),
+				Description: new(fmt.Sprintf("flag_%d", i)),
 				Key:         fmt.Sprintf("flag_key_%d", i),
 			},
 		})
@@ -346,20 +345,20 @@ func TestFindFlags(t *testing.T) {
 		c.CreateSegment(segment.CreateSegmentParams{
 			FlagID: int64(1),
 			Body: &models.CreateSegmentRequest{
-				Description:    util.StringPtr("segment1"),
-				RolloutPercent: util.Int64Ptr(int64(100)),
+				Description:    new("segment1"),
+				RolloutPercent: new(int64(100)),
 			},
 		})
 		c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr("variant1"),
+				Key: new("variant1"),
 			},
 		})
 		c.CreateTag(tag.CreateTagParams{
 			FlagID: int64(1),
 			Body: &models.CreateTagRequest{
-				Value: util.StringPtr("tag1"),
+				Value: new("tag1"),
 			},
 		})
 		res = c.FindFlags(flag.FindFlagsParams{})
@@ -373,24 +372,24 @@ func TestFindFlags(t *testing.T) {
 		c.CreateSegment(segment.CreateSegmentParams{
 			FlagID: 1,
 			Body: &models.CreateSegmentRequest{
-				Description:    util.StringPtr("segment2"),
-				RolloutPercent: util.Int64Ptr(int64(100)),
+				Description:    new("segment2"),
+				RolloutPercent: new(int64(100)),
 			},
 		})
 		c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr("variant2"),
+				Key: new("variant2"),
 			},
 		})
 		c.CreateTag(tag.CreateTagParams{
 			FlagID: int64(1),
 			Body: &models.CreateTagRequest{
-				Value: util.StringPtr("tag2"),
+				Value: new("tag2"),
 			},
 		})
 		res = c.FindFlags(flag.FindFlagsParams{
-			Preload: util.BoolPtr(true),
+			Preload: new(true),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, numOfFlags)
 		assert.NotZero(t, len(res.(*flag.FindFlagsOK).Payload[0].Segments))
@@ -399,38 +398,38 @@ func TestFindFlags(t *testing.T) {
 
 	t.Run("FindFlags (with enabled only) - got all the enabled results", func(t *testing.T) {
 		res = c.FindFlags(flag.FindFlagsParams{
-			Enabled: util.BoolPtr(true),
+			Enabled: new(true),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 0)
 	})
 	t.Run("FindFlags (with matching description)", func(t *testing.T) {
 		res = c.FindFlags(flag.FindFlagsParams{
-			Description: util.StringPtr("flag_1"),
+			Description: new("flag_1"),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 1)
 	})
 	t.Run("FindFlags (with matching key)", func(t *testing.T) {
 		res = c.FindFlags(flag.FindFlagsParams{
-			Key: util.StringPtr("flag_key_1"),
+			Key: new("flag_key_1"),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 1)
 	})
 	t.Run("FindFlags (with matching description_like)", func(t *testing.T) {
 		res = c.FindFlags(flag.FindFlagsParams{
-			DescriptionLike: util.StringPtr("flag_"),
+			DescriptionLike: new("flag_"),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, numOfFlags)
 	})
 	t.Run("FindFlags (with limit)", func(t *testing.T) {
 		res = c.FindFlags(flag.FindFlagsParams{
-			Limit: util.Int64Ptr(int64(2)),
+			Limit: new(int64(2)),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 2)
 	})
 	t.Run("FindFlags (with limit and offset)", func(t *testing.T) {
 		res = c.FindFlags(flag.FindFlagsParams{
-			Limit:  util.Int64Ptr(int64(2)),
-			Offset: util.Int64Ptr(int64(2)),
+			Limit:  new(int64(2)),
+			Offset: new(int64(2)),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 2)
 		assert.Equal(t, res.(*flag.FindFlagsOK).Payload[0].ID, int64(3))
@@ -440,12 +439,12 @@ func TestFindFlags(t *testing.T) {
 		c.CreateTag(tag.CreateTagParams{
 			FlagID: int64(1),
 			Body: &models.CreateTagRequest{
-				Value: util.StringPtr("tag1"),
+				Value: new("tag1"),
 			},
 		})
 
 		res = c.FindFlags(flag.FindFlagsParams{
-			Tags: util.StringPtr("tag1"),
+			Tags: new("tag1"),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 1)
 		assert.Equal(t, res.(*flag.FindFlagsOK).Payload[0].ID, int64(1))
@@ -453,7 +452,7 @@ func TestFindFlags(t *testing.T) {
 	t.Run("FindFlags (deleted Flag)", func(t *testing.T) {
 		res = c.DeleteFlag(flag.DeleteFlagParams{FlagID: int64(1)})
 		res = c.FindFlags(flag.FindFlagsParams{
-			Deleted: util.BoolPtr(true),
+			Deleted: new(true),
 		})
 		assert.Len(t, res.(*flag.FindFlagsOK).Payload, 1)
 	})
@@ -485,7 +484,7 @@ func TestGetFlagSnapshots(t *testing.T) {
 	fb, err := json.Marshal(f)
 	assert.NoError(t, err)
 
-	for i := 0; i < numOfSnapshots; i++ {
+	for range numOfSnapshots {
 		snapshot := entity.FlagSnapshot{
 			FlagID: 1,
 			Flag:   fb,
@@ -501,15 +500,15 @@ func TestGetFlagSnapshots(t *testing.T) {
 
 	t.Run("GetFlagSnapshots (with limit)", func(t *testing.T) {
 		res = c.GetFlagSnapshots(flag.GetFlagSnapshotsParams{
-			Limit: util.Int64Ptr(int64(2)),
+			Limit: new(int64(2)),
 		})
 		assert.Len(t, res.(*flag.GetFlagSnapshotsOK).Payload, 2)
 	})
 
 	t.Run("GetFlagSnapshots (with limit and offset)", func(t *testing.T) {
 		res = c.GetFlagSnapshots(flag.GetFlagSnapshotsParams{
-			Limit:  util.Int64Ptr(int64(2)),
-			Offset: util.Int64Ptr(int64(2)),
+			Limit:  new(int64(2)),
+			Offset: new(int64(2)),
 		})
 		assert.Len(t, res.(*flag.GetFlagSnapshotsOK).Payload, 2)
 		assert.Equal(t, int64(8), res.(*flag.GetFlagSnapshotsOK).Payload[0].ID)
@@ -518,8 +517,8 @@ func TestGetFlagSnapshots(t *testing.T) {
 
 	t.Run("GetFlagSnapshots (sort ascending)", func(t *testing.T) {
 		res = c.GetFlagSnapshots(flag.GetFlagSnapshotsParams{
-			Limit: util.Int64Ptr(int64(2)),
-			Sort:  util.StringPtr("ASC"),
+			Limit: new(int64(2)),
+			Sort:  new("ASC"),
 		})
 		assert.Len(t, res.(*flag.GetFlagSnapshotsOK).Payload, 2)
 		assert.Equal(t, int64(1), res.(*flag.GetFlagSnapshotsOK).Payload[0].ID)
@@ -528,8 +527,8 @@ func TestGetFlagSnapshots(t *testing.T) {
 
 	t.Run("GetFlagSnapshots (sort descending)", func(t *testing.T) {
 		res = c.GetFlagSnapshots(flag.GetFlagSnapshotsParams{
-			Limit: util.Int64Ptr(int64(2)),
-			Sort:  util.StringPtr("DESC"),
+			Limit: new(int64(2)),
+			Sort:  new("DESC"),
 		})
 		assert.Len(t, res.(*flag.GetFlagSnapshotsOK).Payload, 2)
 		assert.Equal(t, int64(10), res.(*flag.GetFlagSnapshotsOK).Payload[0].ID)
@@ -553,7 +552,7 @@ func TestCrudSegments(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 
@@ -561,16 +560,16 @@ func TestCrudSegments(t *testing.T) {
 	res = c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	assert.NotZero(t, res.(*segment.CreateSegmentOK).Payload)
 	res = c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment2"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment2"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	assert.NotZero(t, res.(*segment.CreateSegmentOK).Payload)
@@ -584,8 +583,8 @@ func TestCrudSegments(t *testing.T) {
 		FlagID:    int64(1),
 		SegmentID: int64(1),
 		Body: &models.PutSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(0)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(0)),
 		},
 	})
 	assert.NotZero(t, res.(*segment.PutSegmentOK).Payload.ID)
@@ -626,7 +625,7 @@ func TestCrudSegmentsWithFailures(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 
@@ -642,8 +641,8 @@ func TestCrudSegmentsWithFailures(t *testing.T) {
 		res = c.CreateSegment(segment.CreateSegmentParams{
 			FlagID: int64(1),
 			Body: &models.CreateSegmentRequest{
-				Description:    util.StringPtr("segment1"),
-				RolloutPercent: util.Int64Ptr(int64(100)),
+				Description:    new("segment1"),
+				RolloutPercent: new(int64(100)),
 			},
 		})
 		assert.NotZero(t, res.(*segment.CreateSegmentDefault).Payload)
@@ -655,8 +654,8 @@ func TestCrudSegmentsWithFailures(t *testing.T) {
 			FlagID:    int64(1),
 			SegmentID: int64(999999),
 			Body: &models.PutSegmentRequest{
-				Description:    util.StringPtr("segment1"),
-				RolloutPercent: util.Int64Ptr(int64(0)),
+				Description:    new("segment1"),
+				RolloutPercent: new(int64(0)),
 			},
 		})
 		assert.NotZero(t, res.(*segment.PutSegmentDefault).Payload)
@@ -700,14 +699,14 @@ func TestCrudConstraints(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 
@@ -723,9 +722,9 @@ func TestCrudConstraints(t *testing.T) {
 		FlagID:    int64(1),
 		SegmentID: int64(1),
 		Body: &models.CreateConstraintRequest{
-			Operator: util.StringPtr("EQ"),
-			Property: util.StringPtr("state"),
-			Value:    util.StringPtr(`"NY"`),
+			Operator: new("EQ"),
+			Property: new("state"),
+			Value:    new(`"NY"`),
 		},
 	})
 	assert.NotZero(t, res.(*constraint.CreateConstraintOK).Payload.ID)
@@ -743,9 +742,9 @@ func TestCrudConstraints(t *testing.T) {
 		SegmentID:    int64(1),
 		ConstraintID: int64(1),
 		Body: &models.CreateConstraintRequest{
-			Operator: util.StringPtr("EQ"),
-			Property: util.StringPtr("state"),
-			Value:    util.StringPtr(`"CA"`),
+			Operator: new("EQ"),
+			Property: new("state"),
+			Value:    new(`"CA"`),
 		},
 	})
 	assert.NotZero(t, res.(*constraint.PutConstraintOK).Payload.ID)
@@ -758,9 +757,9 @@ func TestCrudConstraints(t *testing.T) {
 			SegmentID:    int64(1),
 			ConstraintID: int64(1),
 			Body: &models.CreateConstraintRequest{
-				Operator: util.StringPtr("EQ"),
-				Property: util.StringPtr(propertyName),
-				Value:    util.StringPtr(`"CA"`),
+				Operator: new("EQ"),
+				Property: new(propertyName),
+				Value:    new(`"CA"`),
 			},
 		})
 		assert.NotZero(t, res.(*constraint.PutConstraintOK).Payload.ID)
@@ -790,23 +789,23 @@ func TestCrudConstraintsFailures(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	c.CreateConstraint(constraint.CreateConstraintParams{
 		FlagID:    int64(1),
 		SegmentID: int64(1),
 		Body: &models.CreateConstraintRequest{
-			Operator: util.StringPtr("EQ"),
-			Property: util.StringPtr("state"),
-			Value:    util.StringPtr(`"NY"`),
+			Operator: new("EQ"),
+			Property: new("state"),
+			Value:    new(`"NY"`),
 		},
 	})
 
@@ -825,9 +824,9 @@ func TestCrudConstraintsFailures(t *testing.T) {
 			FlagID:    int64(1),
 			SegmentID: int64(1),
 			Body: &models.CreateConstraintRequest{
-				Operator: util.StringPtr("IN"),
-				Property: util.StringPtr("state"),
-				Value:    util.StringPtr(`"NY"]`), // invalid array []
+				Operator: new("IN"),
+				Property: new("state"),
+				Value:    new(`"NY"]`), // invalid array []
 			},
 		})
 		assert.NotZero(t, res.(*constraint.CreateConstraintDefault).Payload)
@@ -839,9 +838,9 @@ func TestCrudConstraintsFailures(t *testing.T) {
 			FlagID:    int64(1),
 			SegmentID: int64(1),
 			Body: &models.CreateConstraintRequest{
-				Operator: util.StringPtr("EQ"),
-				Property: util.StringPtr("state"),
-				Value:    util.StringPtr(`"NY"`), // invalid array []
+				Operator: new("EQ"),
+				Property: new("state"),
+				Value:    new(`"NY"`), // invalid array []
 			},
 		})
 		assert.NotZero(t, res.(*constraint.CreateConstraintDefault).Payload)
@@ -854,9 +853,9 @@ func TestCrudConstraintsFailures(t *testing.T) {
 			SegmentID:    int64(1),
 			ConstraintID: int64(999999),
 			Body: &models.CreateConstraintRequest{
-				Operator: util.StringPtr("EQ"),
-				Property: util.StringPtr("state"),
-				Value:    util.StringPtr(`"CA"`),
+				Operator: new("EQ"),
+				Property: new("state"),
+				Value:    new(`"CA"`),
 			},
 		})
 		assert.NotZero(t, res.(*constraint.PutConstraintDefault).Payload)
@@ -868,9 +867,9 @@ func TestCrudConstraintsFailures(t *testing.T) {
 			SegmentID:    int64(1),
 			ConstraintID: int64(1),
 			Body: &models.CreateConstraintRequest{
-				Operator: util.StringPtr("IN"),
-				Property: util.StringPtr("state"),
-				Value:    util.StringPtr(`"CA"]`),
+				Operator: new("IN"),
+				Property: new("state"),
+				Value:    new(`"CA"]`),
 			},
 		})
 		assert.NotZero(t, res.(*constraint.PutConstraintDefault).Payload)
@@ -903,7 +902,7 @@ func TestCrudVariants(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 
@@ -917,7 +916,7 @@ func TestCrudVariants(t *testing.T) {
 	res = c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 	assert.NotZero(t, res.(*variant.CreateVariantOK).Payload.ID)
@@ -933,7 +932,7 @@ func TestCrudVariants(t *testing.T) {
 		FlagID:    int64(1),
 		VariantID: int64(1),
 		Body: &models.PutVariantRequest{
-			Key: util.StringPtr("another_control"),
+			Key: new("another_control"),
 			Attachment: map[string]any{
 				"valid_string_value": "1",
 			},
@@ -945,7 +944,7 @@ func TestCrudVariants(t *testing.T) {
 		FlagID:    int64(1),
 		VariantID: int64(1),
 		Body: &models.PutVariantRequest{
-			Key: util.StringPtr("another_control"),
+			Key: new("another_control"),
 			Attachment: map[string]any{
 				"valid_int_value": 1,
 			},
@@ -957,7 +956,7 @@ func TestCrudVariants(t *testing.T) {
 		FlagID:    int64(1),
 		VariantID: int64(1),
 		Body: &models.PutVariantRequest{
-			Key: util.StringPtr("another_control"),
+			Key: new("another_control"),
 			Attachment: map[string]any{
 				"valid_structured_value": map[string]any{
 					"string_value": "string",
@@ -991,13 +990,13 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 
@@ -1006,7 +1005,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 		res = c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr("control"),
+				Key: new("control"),
 			},
 		})
 		assert.NotZero(t, res.(*variant.CreateVariantDefault).Payload)
@@ -1016,7 +1015,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 		res = c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr(" 123_invalid_key"),
+				Key: new(" 123_invalid_key"),
 			},
 		})
 		assert.NotZero(t, res.(*variant.CreateVariantDefault).Payload)
@@ -1027,7 +1026,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 		res = c.CreateVariant(variant.CreateVariantParams{
 			FlagID: int64(1),
 			Body: &models.CreateVariantRequest{
-				Key: util.StringPtr("key"),
+				Key: new("key"),
 			},
 		})
 		assert.NotZero(t, res.(*variant.CreateVariantDefault).Payload)
@@ -1048,7 +1047,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 			FlagID:    int64(1),
 			VariantID: int64(999999),
 			Body: &models.PutVariantRequest{
-				Key: util.StringPtr("another_control"),
+				Key: new("another_control"),
 			},
 		})
 		assert.NotZero(t, *res.(*variant.PutVariantDefault).Payload)
@@ -1059,7 +1058,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 			FlagID:    int64(1),
 			VariantID: int64(1),
 			Body: &models.PutVariantRequest{
-				Key: util.StringPtr(" spaces in key 123_invalid_key"),
+				Key: new(" spaces in key 123_invalid_key"),
 			},
 		})
 		assert.NotZero(t, *res.(*variant.PutVariantDefault).Payload)
@@ -1071,7 +1070,7 @@ func TestCrudVariantsWithFailures(t *testing.T) {
 			FlagID:    int64(1),
 			VariantID: int64(1),
 			Body: &models.PutVariantRequest{
-				Key: util.StringPtr("key"),
+				Key: new("key"),
 			},
 		})
 		assert.NotZero(t, *res.(*variant.PutVariantDefault).Payload)
@@ -1112,7 +1111,7 @@ func TestCrudTags(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 
@@ -1126,7 +1125,7 @@ func TestCrudTags(t *testing.T) {
 	res = c.CreateTag(tag.CreateTagParams{
 		FlagID: int64(1),
 		Body: &models.CreateTagRequest{
-			Value: util.StringPtr("tag1"),
+			Value: new("tag1"),
 		},
 	})
 	assert.NotZero(t, res.(*tag.CreateTagOK).Payload.ID)
@@ -1164,13 +1163,13 @@ func TestCrudTagsWithFailures(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateTag(tag.CreateTagParams{
 		FlagID: int64(1),
 		Body: &models.CreateTagRequest{
-			Value: util.StringPtr("tag1"),
+			Value: new("tag1"),
 		},
 	})
 
@@ -1179,7 +1178,7 @@ func TestCrudTagsWithFailures(t *testing.T) {
 		res = c.CreateTag(tag.CreateTagParams{
 			FlagID: int64(1),
 			Body: &models.CreateTagRequest{
-				Value: util.StringPtr("tag1"),
+				Value: new("tag1"),
 			},
 		})
 		assert.NotZero(t, res.(*tag.CreateTagDefault).Payload)
@@ -1222,15 +1221,15 @@ func TestFindAllTags(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 
-	for i := 0; i < numOfTags; i++ {
+	for i := range numOfTags {
 		c.CreateTag(tag.CreateTagParams{
 			FlagID: 1,
 			Body: &models.CreateTagRequest{
-				Value: util.StringPtr(fmt.Sprintf("tag_%d", i)),
+				Value: new(fmt.Sprintf("tag_%d", i)),
 			},
 		})
 	}
@@ -1242,20 +1241,20 @@ func TestFindAllTags(t *testing.T) {
 
 	t.Run("FindAllTags (with matching value_like)", func(t *testing.T) {
 		res = c.FindAllTags(tag.FindAllTagsParams{
-			ValueLike: util.StringPtr("tag_"),
+			ValueLike: new("tag_"),
 		})
 		assert.Len(t, res.(*tag.FindAllTagsOK).Payload, numOfTags)
 	})
 	t.Run("FindAllTags (with limit)", func(t *testing.T) {
 		res = c.FindAllTags(tag.FindAllTagsParams{
-			Limit: util.Int64Ptr(int64(2)),
+			Limit: new(int64(2)),
 		})
 		assert.Len(t, res.(*tag.FindAllTagsOK).Payload, 2)
 	})
 	t.Run("FindAllTags (with limit and offset)", func(t *testing.T) {
 		res = c.FindAllTags(tag.FindAllTagsParams{
-			Limit:  util.Int64Ptr(int64(2)),
-			Offset: util.Int64Ptr(int64(2)),
+			Limit:  new(int64(2)),
+			Offset: new(int64(2)),
 		})
 		assert.Len(t, res.(*tag.FindAllTagsOK).Payload, 2)
 		assert.Equal(t, res.(*tag.FindAllTagsOK).Payload[0].ID, int64(3))
@@ -1277,20 +1276,20 @@ func TestCrudDistributions(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 
@@ -1308,9 +1307,9 @@ func TestCrudDistributions(t *testing.T) {
 		Body: &models.PutDistributionsRequest{
 			Distributions: []*models.Distribution{
 				{
-					Percent:    util.Int64Ptr(int64(100)),
-					VariantID:  util.Int64Ptr(int64(1)),
-					VariantKey: util.StringPtr("control"),
+					Percent:    new(int64(100)),
+					VariantID:  new(int64(1)),
+					VariantKey: new("control"),
 				},
 			},
 		},
@@ -1340,20 +1339,20 @@ func TestCrudDistributionsWithFailures(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 	c.PutDistributions(distribution.PutDistributionsParams{
@@ -1362,9 +1361,9 @@ func TestCrudDistributionsWithFailures(t *testing.T) {
 		Body: &models.PutDistributionsRequest{
 			Distributions: []*models.Distribution{
 				{
-					Percent:    util.Int64Ptr(int64(100)),
-					VariantID:  util.Int64Ptr(int64(1)),
-					VariantKey: util.StringPtr("control"),
+					Percent:    new(int64(100)),
+					VariantID:  new(int64(1)),
+					VariantKey: new("control"),
 				},
 			},
 		},
@@ -1387,9 +1386,9 @@ func TestCrudDistributionsWithFailures(t *testing.T) {
 			Body: &models.PutDistributionsRequest{
 				Distributions: []*models.Distribution{
 					{
-						Percent:    util.Int64Ptr(int64(50)), // not adds up to 100
-						VariantID:  util.Int64Ptr(int64(1)),
-						VariantKey: util.StringPtr("control"),
+						Percent:    new(int64(50)), // not adds up to 100
+						VariantID:  new(int64(1)),
+						VariantKey: new("control"),
 					},
 				},
 			},
@@ -1406,9 +1405,9 @@ func TestCrudDistributionsWithFailures(t *testing.T) {
 			Body: &models.PutDistributionsRequest{
 				Distributions: []*models.Distribution{
 					{
-						Percent:    util.Int64Ptr(int64(100)),
-						VariantID:  util.Int64Ptr(int64(1)),
-						VariantKey: util.StringPtr("control"),
+						Percent:    new(int64(100)),
+						VariantID:  new(int64(1)),
+						VariantKey: new("control"),
 					},
 				},
 			},

--- a/pkg/handler/error.go
+++ b/pkg/handler/error.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"fmt"
 
-	"github.com/openflagr/flagr/pkg/util"
 	"github.com/openflagr/flagr/swagger_gen/models"
 )
 
@@ -31,6 +30,6 @@ func NewError(statusCode int, msg string, values ...any) *Error {
 // ErrorMessage generates error messages
 func ErrorMessage(s string, data ...any) *models.Error {
 	return &models.Error{
-		Message: util.StringPtr(fmt.Sprintf(s, data...)),
+		Message: new(fmt.Sprintf(s, data...)),
 	}
 }

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"maps"
 	"sync"
 	"time"
 
@@ -90,9 +91,7 @@ func (ec *EvalCache) getByTagsANY(tags []string) map[uint]*entity.Flag {
 	for _, t := range tags {
 		fSet, ok := ec.cache.tagCache[t]
 		if ok {
-			for fID, f := range fSet {
-				results[fID] = f
-			}
+			maps.Copy(results, fSet)
 		}
 	}
 	return results
@@ -113,9 +112,7 @@ func (ec *EvalCache) getByTagsALL(tags []string) map[uint]*entity.Flag {
 
 		if i == 0 {
 			// store all the flags
-			for fID, f := range fSet {
-				results[fID] = f
-			}
+			maps.Copy(results, fSet)
 		} else {
 			for fID := range results {
 				if _, ok := fSet[fID]; !ok {

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -381,7 +381,7 @@ func TestEvalFlagDistribution(t *testing.T) {
 
 	t.Run("test distribution on integers", func(t *testing.T) {
 		cnt := make(map[int64]int)
-		for i := 0; i < num; i++ {
+		for i := range num {
 			result := EvalFlag(models.EvalContext{
 				EnableDebug:   false,
 				EntityContext: map[string]any{"dl_state": "CA"},
@@ -401,7 +401,7 @@ func TestEvalFlagDistribution(t *testing.T) {
 
 	t.Run("test distribution on secure random key generator", func(t *testing.T) {
 		cnt := make(map[int64]int)
-		for i := 0; i < num; i++ {
+		for range num {
 			result := EvalFlag(models.EvalContext{
 				EnableDebug:   false,
 				EntityContext: map[string]any{"dl_state": "CA"},
@@ -421,7 +421,7 @@ func TestEvalFlagDistribution(t *testing.T) {
 
 	t.Run("test distribution on uuid", func(t *testing.T) {
 		cnt := make(map[int64]int)
-		for i := 0; i < num; i++ {
+		for range num {
 			result := EvalFlag(models.EvalContext{
 				EnableDebug:   false,
 				EntityContext: map[string]any{"dl_state": "CA"},
@@ -441,7 +441,7 @@ func TestEvalFlagDistribution(t *testing.T) {
 
 	t.Run("test distribution on random string + int", func(t *testing.T) {
 		cnt := make(map[int64]int)
-		for i := 0; i < num; i++ {
+		for i := range num {
 			result := EvalFlag(models.EvalContext{
 				EnableDebug:   false,
 				EntityContext: map[string]any{"dl_state": "CA"},
@@ -814,7 +814,7 @@ func TestTagsPostEvaluationBatch(t *testing.T) {
 func TestRateLimitPerFlagConsoleLogging(t *testing.T) {
 	r := &models.EvalResult{FlagID: 1}
 	t.Run("running fast triggers rate limiting", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			rateLimitPerFlagConsoleLogging(r)
 		}
 	})
@@ -857,7 +857,7 @@ func genBenchmarkEvalCache(numFlags int) (*EvalCache, []int64, []string) {
 	flagIDs := make([]int64, 0, numFlags)
 	flagKeys := make([]string, 0, numFlags)
 
-	for i := 0; i < numFlags; i++ {
+	for i := range numFlags {
 		f := entity.GenFixtureFlag()
 		f.ID = uint(100 + i)
 		f.Key = fmt.Sprintf("flag_key_%d", 100+i)

--- a/pkg/handler/export_test.go
+++ b/pkg/handler/export_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/openflagr/flagr/pkg/entity"
-	"github.com/openflagr/flagr/pkg/util"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/export"
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
@@ -104,7 +103,7 @@ func TestExportSQLiteFile(t *testing.T) {
 	})
 
 	t.Run("happy code path and exclude_snapshots", func(t *testing.T) {
-		f, done, err := exportSQLiteFile(util.BoolPtr(true))
+		f, done, err := exportSQLiteFile(new(true))
 		defer done()
 
 		assert.NoError(t, err)

--- a/pkg/handler/validate_test.go
+++ b/pkg/handler/validate_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/openflagr/flagr/pkg/entity"
-	"github.com/openflagr/flagr/pkg/util"
 	"github.com/openflagr/flagr/swagger_gen/models"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/distribution"
 	"github.com/openflagr/flagr/swagger_gen/restapi/operations/flag"
@@ -31,20 +30,20 @@ func TestValidatePutDistributions(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 
@@ -55,9 +54,9 @@ func TestValidatePutDistributions(t *testing.T) {
 			Body: &models.PutDistributionsRequest{
 				Distributions: []*models.Distribution{
 					{
-						Percent:    util.Int64Ptr(int64(100)),
-						VariantID:  util.Int64Ptr(int64(1)),
-						VariantKey: util.StringPtr("control"),
+						Percent:    new(int64(100)),
+						VariantID:  new(int64(1)),
+						VariantKey: new("control"),
 					},
 				},
 			},
@@ -74,8 +73,8 @@ func TestValidatePutDistributions(t *testing.T) {
 				Distributions: []*models.Distribution{
 					{
 						Percent:    nil,
-						VariantID:  util.Int64Ptr(int64(1)),
-						VariantKey: util.StringPtr("control"),
+						VariantID:  new(int64(1)),
+						VariantKey: new("control"),
 					},
 				},
 			},
@@ -91,9 +90,9 @@ func TestValidatePutDistributions(t *testing.T) {
 			Body: &models.PutDistributionsRequest{
 				Distributions: []*models.Distribution{
 					{
-						Percent:    util.Int64Ptr(int64(100)),
-						VariantID:  util.Int64Ptr(int64(1)),
-						VariantKey: util.StringPtr("control"),
+						Percent:    new(int64(100)),
+						VariantID:  new(int64(1)),
+						VariantKey: new("control"),
 					},
 				},
 			},
@@ -109,9 +108,9 @@ func TestValidatePutDistributions(t *testing.T) {
 			Body: &models.PutDistributionsRequest{
 				Distributions: []*models.Distribution{
 					{
-						Percent:    util.Int64Ptr(int64(100)),
-						VariantID:  util.Int64Ptr(int64(999999)),
-						VariantKey: util.StringPtr("control"),
+						Percent:    new(int64(100)),
+						VariantID:  new(int64(999999)),
+						VariantKey: new("control"),
 					},
 				},
 			},
@@ -127,9 +126,9 @@ func TestValidatePutDistributions(t *testing.T) {
 			Body: &models.PutDistributionsRequest{
 				Distributions: []*models.Distribution{
 					{
-						Percent:    util.Int64Ptr(int64(100)),
-						VariantID:  util.Int64Ptr(int64(1)),
-						VariantKey: util.StringPtr("treatment"),
+						Percent:    new(int64(100)),
+						VariantID:  new(int64(1)),
+						VariantKey: new("treatment"),
 					},
 				},
 			},
@@ -153,26 +152,26 @@ func TestValidateDeleteVariant(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("treatment"),
+			Key: new("treatment"),
 		},
 	})
 	c.PutDistributions(distribution.PutDistributionsParams{
@@ -181,14 +180,14 @@ func TestValidateDeleteVariant(t *testing.T) {
 		Body: &models.PutDistributionsRequest{
 			Distributions: []*models.Distribution{
 				{
-					Percent:    util.Int64Ptr(int64(100)),
-					VariantID:  util.Int64Ptr(int64(1)),
-					VariantKey: util.StringPtr("control"),
+					Percent:    new(int64(100)),
+					VariantID:  new(int64(1)),
+					VariantKey: new("control"),
 				},
 				{
-					Percent:    util.Int64Ptr(int64(0)),
-					VariantID:  util.Int64Ptr(int64(2)),
-					VariantKey: util.StringPtr("treatment"),
+					Percent:    new(int64(0)),
+					VariantID:  new(int64(2)),
+					VariantKey: new("treatment"),
 				},
 			},
 		},
@@ -227,26 +226,26 @@ func TestValidatePutVariantForDistributions(t *testing.T) {
 
 	c.CreateFlag(flag.CreateFlagParams{
 		Body: &models.CreateFlagRequest{
-			Description: util.StringPtr("funny flag"),
+			Description: new("funny flag"),
 		},
 	})
 	c.CreateSegment(segment.CreateSegmentParams{
 		FlagID: int64(1),
 		Body: &models.CreateSegmentRequest{
-			Description:    util.StringPtr("segment1"),
-			RolloutPercent: util.Int64Ptr(int64(100)),
+			Description:    new("segment1"),
+			RolloutPercent: new(int64(100)),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("control"),
+			Key: new("control"),
 		},
 	})
 	c.CreateVariant(variant.CreateVariantParams{
 		FlagID: int64(1),
 		Body: &models.CreateVariantRequest{
-			Key: util.StringPtr("treatment"),
+			Key: new("treatment"),
 		},
 	})
 	c.PutDistributions(distribution.PutDistributionsParams{
@@ -255,14 +254,14 @@ func TestValidatePutVariantForDistributions(t *testing.T) {
 		Body: &models.PutDistributionsRequest{
 			Distributions: []*models.Distribution{
 				{
-					Percent:    util.Int64Ptr(int64(100)),
-					VariantID:  util.Int64Ptr(int64(1)),
-					VariantKey: util.StringPtr("control"),
+					Percent:    new(int64(100)),
+					VariantID:  new(int64(1)),
+					VariantKey: new("control"),
 				},
 				{
-					Percent:    util.Int64Ptr(int64(0)),
-					VariantID:  util.Int64Ptr(int64(2)),
-					VariantKey: util.StringPtr("treatment"),
+					Percent:    new(int64(0)),
+					VariantID:  new(int64(2)),
+					VariantKey: new("treatment"),
 				},
 			},
 		},

--- a/pkg/mapper/entity_restapi/e2r/e2r.go
+++ b/pkg/mapper/entity_restapi/e2r/e2r.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openflagr/flagr/pkg/entity"
-	"github.com/openflagr/flagr/pkg/util"
 
 	"github.com/openflagr/flagr/swagger_gen/models"
 )
@@ -18,11 +17,11 @@ func MapFlag(e *entity.Flag) (*models.Flag, error) {
 	r.ID = int64(e.ID)
 	r.Key = e.Key
 	r.CreatedBy = e.CreatedBy
-	r.DataRecordsEnabled = util.BoolPtr(e.DataRecordsEnabled)
+	r.DataRecordsEnabled = new(e.DataRecordsEnabled)
 	r.EntityType = e.EntityType
-	r.Description = util.StringPtr(e.Description)
+	r.Description = new(e.Description)
 	r.Notes = e.Notes
-	r.Enabled = util.BoolPtr(e.Enabled)
+	r.Enabled = new(e.Enabled)
 	r.UpdatedAt = strfmt.DateTime(e.UpdatedAt)
 	r.UpdatedBy = e.UpdatedBy
 	r.Segments = MapSegments(e.Segments)
@@ -59,7 +58,7 @@ func MapFlagSnapshot(e *entity.FlagSnapshot) (*models.FlagSnapshot, error) {
 		Flag:      f,
 		ID:        int64(e.ID),
 		UpdatedBy: e.UpdatedBy,
-		UpdatedAt: util.StringPtr(e.UpdatedAt.UTC().Format(time.RFC3339)),
+		UpdatedAt: new(e.UpdatedAt.UTC().Format(time.RFC3339)),
 	}
 	return r, nil
 }
@@ -81,9 +80,9 @@ func MapFlagSnapshots(e []entity.FlagSnapshot) ([]*models.FlagSnapshot, error) {
 func MapSegment(e *entity.Segment) *models.Segment {
 	r := &models.Segment{}
 	r.ID = int64(e.ID)
-	r.Description = util.StringPtr(e.Description)
-	r.Rank = util.Int64Ptr(int64(e.Rank))
-	r.RolloutPercent = util.Int64Ptr(int64(e.RolloutPercent))
+	r.Description = new(e.Description)
+	r.Rank = new(int64(e.Rank))
+	r.RolloutPercent = new(int64(e.RolloutPercent))
 	r.Constraints = MapConstraints(e.Constraints)
 	r.Distributions = MapDistributions(e.Distributions)
 	return r
@@ -102,7 +101,7 @@ func MapSegments(e []entity.Segment) []*models.Segment {
 func MapTag(e *entity.Tag) *models.Tag {
 	r := &models.Tag{}
 	r.ID = int64(e.ID)
-	r.Value = util.StringPtr(e.Value)
+	r.Value = new(e.Value)
 	return r
 }
 
@@ -119,9 +118,9 @@ func MapTags(e []entity.Tag) []*models.Tag {
 func MapConstraint(e *entity.Constraint) *models.Constraint {
 	r := &models.Constraint{}
 	r.ID = int64(e.ID)
-	r.Property = util.StringPtr(e.Property)
-	r.Operator = util.StringPtr(e.Operator)
-	r.Value = util.StringPtr(e.Value)
+	r.Property = new(e.Property)
+	r.Operator = new(e.Operator)
+	r.Value = new(e.Value)
 	return r
 }
 
@@ -138,9 +137,9 @@ func MapConstraints(e []entity.Constraint) []*models.Constraint {
 func MapDistribution(e *entity.Distribution) *models.Distribution {
 	r := &models.Distribution{
 		ID:         int64(e.ID),
-		Percent:    util.Int64Ptr(int64(e.Percent)),
-		VariantID:  util.Int64Ptr(int64(e.VariantID)),
-		VariantKey: util.StringPtr(e.VariantKey),
+		Percent:    new(int64(e.Percent)),
+		VariantID:  new(int64(e.VariantID)),
+		VariantKey: new(e.VariantKey),
 	}
 	return r
 }
@@ -158,7 +157,7 @@ func MapDistributions(e []entity.Distribution) []*models.Distribution {
 func MapVariant(e *entity.Variant) *models.Variant {
 	r := &models.Variant{
 		ID:         int64(e.ID),
-		Key:        util.StringPtr(e.Key),
+		Key:        new(e.Key),
 		Attachment: e.Attachment,
 	}
 	return r

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -97,36 +97,3 @@ func Round(f float64) int {
 func TimeNow() string {
 	return time.Now().UTC().Format(time.RFC3339)
 }
-
-// Float32Ptr ...
-func Float32Ptr(v float32) *float32 { return &v }
-
-// Float64Ptr ...
-func Float64Ptr(v float64) *float64 { return &v }
-
-// IntPtr ...
-func IntPtr(v int) *int { return &v }
-
-// Int32Ptr ...
-func Int32Ptr(v int32) *int32 { return &v }
-
-// Int64Ptr ...
-func Int64Ptr(v int64) *int64 { return &v }
-
-// StringPtr ...
-func StringPtr(v string) *string { return &v }
-
-// UintPtr ...
-func UintPtr(v uint) *uint { return &v }
-
-// Uint32Ptr ...
-func Uint32Ptr(v uint32) *uint32 { return &v }
-
-// Uint64Ptr ...
-func Uint64Ptr(v uint64) *uint64 { return &v }
-
-// BoolPtr ...
-func BoolPtr(v bool) *bool { return &v }
-
-// ByteSlicePtr ...
-func ByteSlicePtr(v []byte) *[]byte { return &v }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSafeString(t *testing.T) {
 	assert.Equal(t, SafeString("123"), "123")
-	assert.Equal(t, SafeString(StringPtr("123")), "123")
+	assert.Equal(t, SafeString(new("123")), "123")
 	assert.Equal(t, SafeString(123), "123")
 	assert.Equal(t, SafeString(nil), "")
 
@@ -19,12 +19,12 @@ func TestSafeString(t *testing.T) {
 
 func TestSafeStringWithDefault(t *testing.T) {
 	assert.Equal(t, SafeStringWithDefault("123", ""), "123")
-	assert.Equal(t, SafeStringWithDefault(StringPtr("123"), ""), "123")
+	assert.Equal(t, SafeStringWithDefault(new("123"), ""), "123")
 	assert.Equal(t, SafeStringWithDefault(123, ""), "123")
 	assert.Equal(t, SafeStringWithDefault(nil, ""), "")
 
 	assert.Equal(t, SafeStringWithDefault("123", "<nil>"), "123")
-	assert.Equal(t, SafeStringWithDefault(StringPtr("123"), "<nil>"), "123")
+	assert.Equal(t, SafeStringWithDefault(new("123"), "<nil>"), "123")
 	assert.Equal(t, SafeStringWithDefault(123, "<nil>"), "123")
 	assert.Equal(t, SafeStringWithDefault(nil, "<nil>"), "<nil>")
 }
@@ -34,24 +34,24 @@ func TestSafeUint(t *testing.T) {
 	assert.Equal(t, SafeUint("123"), uint(123))
 
 	assert.Equal(t, SafeUint(int(1)), uint(1))
-	assert.Equal(t, SafeUint(IntPtr(1)), uint(1))
+	assert.Equal(t, SafeUint(new(1)), uint(1))
 	assert.Equal(t, SafeUint(int32(1)), uint(1))
-	assert.Equal(t, SafeUint(Int32Ptr(1)), uint(1))
+	assert.Equal(t, SafeUint(new(int32(1))), uint(1))
 	assert.Equal(t, SafeUint(int64(1)), uint(1))
-	assert.Equal(t, SafeUint(Int64Ptr(1)), uint(1))
+	assert.Equal(t, SafeUint(new(int64(1))), uint(1))
 	assert.Equal(t, SafeUint(uint(1)), uint(1))
-	assert.Equal(t, SafeUint(UintPtr(1)), uint(1))
+	assert.Equal(t, SafeUint(new(uint(1))), uint(1))
 	assert.Equal(t, SafeUint(uint32(1)), uint(1))
-	assert.Equal(t, SafeUint(Uint32Ptr(1)), uint(1))
+	assert.Equal(t, SafeUint(new(uint32(1))), uint(1))
 	assert.Equal(t, SafeUint(uint64(1)), uint(1))
-	assert.Equal(t, SafeUint(Uint64Ptr(1)), uint(1))
+	assert.Equal(t, SafeUint(new(uint64(1))), uint(1))
 	assert.Equal(t, SafeUint(int32(1)), uint(1))
 	assert.Equal(t, SafeUint(int64(1)), uint(1))
 
 	assert.Equal(t, SafeUint(float32(123)), uint(123))
-	assert.Equal(t, SafeUint(Float32Ptr(float32(123))), uint(123))
+	assert.Equal(t, SafeUint(new(float32(123))), uint(123))
 	assert.Equal(t, SafeUint(float64(123)), uint(123))
-	assert.Equal(t, SafeUint(Float64Ptr(float64(123))), uint(123))
+	assert.Equal(t, SafeUint(new(float64(123))), uint(123))
 
 	var ptr *int64
 	assert.Equal(t, SafeUint(ptr), uint(0))
@@ -162,20 +162,6 @@ func TestIsSafeValue(t *testing.T) {
 	assert.True(t, b)
 	assert.Empty(t, msg)
 }
-func TestPtrs(t *testing.T) {
-	assert.Equal(t, "a", *StringPtr("a"))
-	assert.Equal(t, int(1), *IntPtr(int(1)))
-	assert.Equal(t, int32(1), *Int32Ptr(int32(1)))
-	assert.Equal(t, int64(1), *Int64Ptr(int64(1)))
-	assert.Equal(t, float32(1.0), *Float32Ptr(float32(1.0)))
-	assert.Equal(t, float64(1.0), *Float64Ptr(float64(1.0)))
-	assert.Equal(t, uint(1), *UintPtr(uint(1)))
-	assert.Equal(t, uint32(1), *Uint32Ptr(uint32(1)))
-	assert.Equal(t, uint64(1), *Uint64Ptr(uint64(1)))
-	assert.Equal(t, true, *BoolPtr(true))
-	assert.Equal(t, []byte("abc"), *ByteSlicePtr([]byte("abc")))
-}
-
 func TestRound(t *testing.T) {
 	assert.Equal(t, Round(float64(1.01)), 1)
 	assert.Equal(t, Round(float64(1.99)), 2)


### PR DESCRIPTION
Replaced deprecated `util.*Ptr` functions with Go 1.26 `new(val)` syntax. Verified all usages are updated and tests pass.