### PR TITLE
Upgrade conditions to v0.2.5 with nested field constraint support

### DIFF
--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -1233,6 +1233,10 @@ definitions:
       property:
         type: string
         minLength: 1
+        description: >
+          The property name from the entity context to evaluate. Supports nested
+          field access: use dots (e.g., `user.name`)  for nested objects and
+          brackets (e.g., `users[0]`) for array indices.
       operator:
         type: string
         minLength: 1
@@ -1262,6 +1266,10 @@ definitions:
       property:
         type: string
         minLength: 1
+        description: >
+          The property name from the entity context to evaluate. Supports nested
+          field access: use dots (e.g., `user.name`)  for nested objects and
+          brackets (e.g., `users[0]`) for array indices.
       operator:
         type: string
         minLength: 1

--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -10,6 +10,12 @@ The definitions of the following concepts are in [API doc](https://openflagr.git
 - **Variant Attachment** represents the dynamic configuration of a variant. For example, if you have a variant for the `green` button, you can dynamically control what's the hex color of green you want to use (e.g. `{"hex_color": "#42b983"}`).
 - **Segment** represents the segmentation, i.e. the set of audience we want to target. Segment is the smallest unit of a component we can analyze in Flagr Metrics.
 - **Constraint** represents rules that we can use to define the audience of the segment. In other words, the audience in the segment is defined by a set of constraints. Specifically, in Flagr, the constraints are connected with `AND` in a segment.
+
+  Constraint properties support nested field access using dotted and bracketed syntax:
+  - `user.name` — accesses `args["user"]["name"]` from a nested entity context
+  - `users[0]` — accesses the first element of `args["users"]` array
+  - `users[0].role` — chained array + property access
+  - Simple flat properties like `state` or `age` work as before.
 - **Distribution** represents the distribution of variants in a segment.
 - **Entity** represents the context of what we are going to assign the variant on. Usually, Flagr expects the context coming with the entity, so that one can define constraints based on the context of the entity.
 - **Rollout** and deterministic random logic. The goal here is to ensure deterministic and persistent evaluation result for entities. Steps to evaluating a flag given an entity context:

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/urfave/negroni v1.0.0
 	github.com/yadvendar/negroni-newrelic-go-agent v0.0.0-20160803090806-3dc58758cb67
-	github.com/zhouzhuojie/conditions v0.2.4
+	github.com/zhouzhuojie/conditions v0.2.5
 	github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5
 	golang.org/x/net v0.48.0
 	google.golang.org/api v0.257.0

--- a/go.sum
+++ b/go.sum
@@ -428,6 +428,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zhouzhuojie/conditions v0.2.4 h1:mgrhd6uA9befUchbvrmekohWk+9waGsUr2WS1bgzzX0=
 github.com/zhouzhuojie/conditions v0.2.4/go.mod h1:fSgYEsOx1XDtsXWYM9lJkn3XTU73xsso3as8Yhqmaz0=
+github.com/zhouzhuojie/conditions v0.2.5 h1:xLLZ47yOk7UuJPVXsllNYes6/N36DIoEJiWi4h/xIew=
+github.com/zhouzhuojie/conditions v0.2.5/go.mod h1:fSgYEsOx1XDtsXWYM9lJkn3XTU73xsso3as8Yhqmaz0=
 github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5 h1:YuR5otuPvpk6EPrKy9rVXiQKTqgY6OEqSlzko9kcfCI=
 github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5/go.mod h1:nhm/3zpPm56iKoXLEeeevuI5V9qEtNhuhLbPZwcrgcs=
 go.einride.tech/aip v0.73.0 h1:bPo4oqBo2ZQeBKo4ZzLb1kxYXTY1ysJhpvQyfuGzvps=

--- a/pkg/entity/constraint_test.go
+++ b/pkg/entity/constraint_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openflagr/flagr/swagger_gen/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/zhouzhuojie/conditions"
 )
 
 func TestConstraintToExpr(t *testing.T) {
@@ -123,4 +124,265 @@ func TestConstraintArray(t *testing.T) {
 	expr, err := cs.ToExpr()
 	assert.NoError(t, err)
 	assert.NotNil(t, expr)
+}
+
+func TestConstraintToExpr_NestedField(t *testing.T) {
+	t.Run("dotted path property - EQ", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.name",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    `"Alice"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		// Should produce: ({user.name} == "Alice")
+		// Evaluated against nested context: {"user": {"name": "Alice"}}
+		match, err := conditions.Evaluate(expr, map[string]any{"user": map[string]any{"name": "Alice"}})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{"user": map[string]any{"name": "Bob"}})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("dotted path property - GT", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.age",
+			Operator: models.ConstraintOperatorGT,
+			Value:    "18",
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{"user": map[string]any{"age": float64(25)}})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{"user": map[string]any{"age": float64(15)}})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("array index property", func(t *testing.T) {
+		c := Constraint{
+			Property: "users[0]",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    `"admin"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"users": []any{"admin", "viewer"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{
+			"users": []any{"viewer", "admin"},
+		})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("array index with dot chained", func(t *testing.T) {
+		c := Constraint{
+			Property: "users[0].name",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    `"Alice"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"users": []any{
+				map[string]any{"name": "Alice"},
+				map[string]any{"name": "Bob"},
+			},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("nested path with IN operator", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.role",
+			Operator: models.ConstraintOperatorIN,
+			Value:    `["admin", "moderator"]`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{"user": map[string]any{"role": "admin"}})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{"user": map[string]any{"role": "viewer"}})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("nested path with CONTAINS", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.tags",
+			Operator: models.ConstraintOperatorCONTAINS,
+			Value:    `"urgent"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"tags": []string{"urgent", "billing"}},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"tags": []string{"normal", "billing"}},
+		})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("nested path with regex (string pattern)", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"^5[0-9][0-9]$"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"status": "500"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"status": "400"},
+		})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("nested path with regex (literal pattern)", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `/^5[0-9][0-9]$/`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"status": "500"},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"status": "400"},
+		})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("nested path with NOT CONTAINS", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.exclusions",
+			Operator: models.ConstraintOperatorNOTCONTAINS,
+			Value:    `"banned"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		assert.NotNil(t, expr)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"exclusions": []string{"active"}},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("nested path validates correctly", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.name",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    `"Alice"`,
+		}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("nested path with missing key errors", func(t *testing.T) {
+		c := Constraint{
+			Property: "user.missing",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    `"Alice"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+
+		_, err = conditions.Evaluate(expr, map[string]any{"user": map[string]any{"name": "Alice"}})
+		assert.Error(t, err)
+	})
+
+	t.Run("deeply nested path", func(t *testing.T) {
+		c := Constraint{
+			Property: "a.b.c.d",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    "42",
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"a": map[string]any{
+				"b": map[string]any{
+					"c": map[string]any{"d": float64(42)},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("nested path in ConstraintArray", func(t *testing.T) {
+		cs := ConstraintArray{
+			{
+				Property: "user.tier",
+				Operator: models.ConstraintOperatorIN,
+				Value:    `["premium", "enterprise"]`,
+			},
+			{
+				Property: "user.age",
+				Operator: models.ConstraintOperatorGT,
+				Value:    "18",
+			},
+		}
+		expr, err := cs.ToExpr()
+		assert.NoError(t, err)
+
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"tier": "premium", "age": float64(25)},
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+
+		match, err = conditions.Evaluate(expr, map[string]any{
+			"user": map[string]any{"tier": "free", "age": float64(25)},
+		})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
 }

--- a/pkg/handler/eval_test.go
+++ b/pkg/handler/eval_test.go
@@ -146,6 +146,144 @@ func TestEvalSegment(t *testing.T) {
 	})
 }
 
+func TestEvalSegment_NestedEntityContext(t *testing.T) {
+	t.Run("nested dotted path constraint matches nested entity context", func(t *testing.T) {
+		s := entity.GenFixtureSegment()
+		s.Constraints = []entity.Constraint{
+			{
+				Property: "user.name",
+				Operator: models.ConstraintOperatorEQ,
+				Value:    `"Alice"`,
+			},
+			{
+				Property: "user.age",
+				Operator: models.ConstraintOperatorGT,
+				Value:    "18",
+			},
+		}
+		s.PrepareEvaluation()
+
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug: true,
+			EntityContext: map[string]any{
+				"user": map[string]any{
+					"name": "Alice",
+					"age":  float64(25),
+				},
+			},
+			EntityID:   "entityID1",
+			EntityType: "entityType1",
+			FlagID:     int64(100),
+		}, s)
+
+		assert.NotNil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.False(t, evalNextSegment)
+	})
+
+	t.Run("nested dotted path constraint no match", func(t *testing.T) {
+		s := entity.GenFixtureSegment()
+		s.Constraints = []entity.Constraint{
+			{
+				Property: "user.name",
+				Operator: models.ConstraintOperatorEQ,
+				Value:    `"Alice"`,
+			},
+		}
+		s.PrepareEvaluation()
+
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]any{"user": map[string]any{"name": "Bob"}},
+			EntityID:      "entityID1",
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		}, s)
+
+		assert.Nil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.True(t, evalNextSegment)
+	})
+
+	t.Run("nested array index constraint matches", func(t *testing.T) {
+		s := entity.GenFixtureSegment()
+		s.Constraints = []entity.Constraint{
+			{
+				Property: "roles[0]",
+				Operator: models.ConstraintOperatorEQ,
+				Value:    `"admin"`,
+			},
+		}
+		s.PrepareEvaluation()
+
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]any{"roles": []any{"admin", "editor"}},
+			EntityID:      "entityID1",
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		}, s)
+
+		assert.NotNil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.False(t, evalNextSegment)
+	})
+
+	t.Run("nested chained path (array + dot) matches", func(t *testing.T) {
+		s := entity.GenFixtureSegment()
+		s.Constraints = []entity.Constraint{
+			{
+				Property: "users[0].tier",
+				Operator: models.ConstraintOperatorIN,
+				Value:    `["premium", "enterprise"]`,
+			},
+		}
+		s.PrepareEvaluation()
+
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug: true,
+			EntityContext: map[string]any{
+				"users": []any{
+					map[string]any{"tier": "premium"},
+				},
+			},
+			EntityID:   "entityID1",
+			EntityType: "entityType1",
+			FlagID:     int64(100),
+		}, s)
+
+		assert.NotNil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.False(t, evalNextSegment)
+	})
+
+	t.Run("nested path with missing key errors gracefully", func(t *testing.T) {
+		s := entity.GenFixtureSegment()
+		s.Constraints = []entity.Constraint{
+			{
+				Property: "user.missing_field",
+				Operator: models.ConstraintOperatorEQ,
+				Value:    `"value"`,
+			},
+		}
+		s.PrepareEvaluation()
+
+		// When a nested key is missing, the constraint evaluation should error
+		// and the segment should not match (evalNextSegment = true means try next)
+		vID, log, evalNextSegment := evalSegment(100, models.EvalContext{
+			EnableDebug:   true,
+			EntityContext: map[string]any{"user": map[string]any{"name": "Alice"}},
+			EntityID:      "entityID1",
+			EntityType:    "entityType1",
+			FlagID:        int64(100),
+		}, s)
+
+		assert.Nil(t, vID)
+		assert.NotEmpty(t, log)
+		assert.True(t, evalNextSegment)
+	})
+}
+
 func TestEvalFlag(t *testing.T) {
 	defer gostub.StubFunc(&logEvalResult).Reset()
 

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -362,6 +362,10 @@ definitions:
       property:
         type: string
         minLength: 1
+        description: >
+          The property name from the entity context to evaluate.
+          Supports nested field access: use dots (e.g., `user.name`) 
+          for nested objects and brackets (e.g., `users[0]`) for array indices.
       operator:
         type: string
         minLength: 1
@@ -391,6 +395,10 @@ definitions:
       property:
         type: string
         minLength: 1
+        description: >
+          The property name from the entity context to evaluate.
+          Supports nested field access: use dots (e.g., `user.name`) 
+          for nested objects and brackets (e.g., `users[0]`) for array indices.
       operator:
         type: string
         minLength: 1

--- a/swagger_gen/models/constraint.go
+++ b/swagger_gen/models/constraint.go
@@ -31,7 +31,8 @@ type Constraint struct {
 	// Enum: ["EQ","NEQ","LT","LTE","GT","GTE","EREG","NEREG","IN","NOTIN","CONTAINS","NOTCONTAINS"]
 	Operator *string `json:"operator"`
 
-	// property
+	// The property name from the entity context to evaluate. Supports nested field access: use dots (e.g., `user.name`)  for nested objects and brackets (e.g., `users[0]`) for array indices.
+	//
 	// Required: true
 	// Min Length: 1
 	Property *string `json:"property"`

--- a/swagger_gen/models/create_constraint_request.go
+++ b/swagger_gen/models/create_constraint_request.go
@@ -24,7 +24,8 @@ type CreateConstraintRequest struct {
 	// Min Length: 1
 	Operator *string `json:"operator"`
 
-	// property
+	// The property name from the entity context to evaluate. Supports nested field access: use dots (e.g., `user.name`)  for nested objects and brackets (e.g., `users[0]`) for array indices.
+	//
 	// Required: true
 	// Min Length: 1
 	Property *string `json:"property"`

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -1422,6 +1422,7 @@ func init() {
           ]
         },
         "property": {
+          "description": "The property name from the entity context to evaluate. Supports nested field access: use dots (e.g., ` + "`" + `user.name` + "`" + `)  for nested objects and brackets (e.g., ` + "`" + `users[0]` + "`" + `) for array indices.\n",
           "type": "string",
           "minLength": 1
         },
@@ -1444,6 +1445,7 @@ func init() {
           "minLength": 1
         },
         "property": {
+          "description": "The property name from the entity context to evaluate. Supports nested field access: use dots (e.g., ` + "`" + `user.name` + "`" + `)  for nested objects and brackets (e.g., ` + "`" + `users[0]` + "`" + `) for array indices.\n",
           "type": "string",
           "minLength": 1
         },
@@ -3519,6 +3521,7 @@ func init() {
           ]
         },
         "property": {
+          "description": "The property name from the entity context to evaluate. Supports nested field access: use dots (e.g., ` + "`" + `user.name` + "`" + `)  for nested objects and brackets (e.g., ` + "`" + `users[0]` + "`" + `) for array indices.\n",
           "type": "string",
           "minLength": 1
         },
@@ -3541,6 +3544,7 @@ func init() {
           "minLength": 1
         },
         "property": {
+          "description": "The property name from the entity context to evaluate. Supports nested field access: use dots (e.g., ` + "`" + `user.name` + "`" + `)  for nested objects and brackets (e.g., ` + "`" + `users[0]` + "`" + `) for array indices.\n",
           "type": "string",
           "minLength": 1
         },


### PR DESCRIPTION
## Summary

Upgrades `github.com/zhouzhuojie/conditions` from `v0.2.4` to `v0.2.5`, which introduces nested JSON path traversal support via the new `PathRef` AST node.

## What's New

Constraint **Property** fields now support nested field access:

| Property Syntax | Resolves To |
|---|---|
| `user.name` | `args["user"]["name"]` |
| `users[0]` | `args["users"][0]` |
| `users[0].role` | `args["users"][0]["role"]` |
| `a.b.c` | `args["a"]["b"]["c"]` |
| `matrix[0][1]` | `args["matrix"][0][1]` |

All existing operators (EQ, NEQ, IN, CONTAINS, EREG, etc.) work with nested paths.

## What Changed

### Backend
- **`go.mod`** / **`go.sum`** — conditions `v0.2.4` → `v0.2.5`
- **No code changes** — the existing `toExprStr()` already wraps Property in `{}`, which the new parser handles

### Tests
- **`pkg/entity/constraint_test.go`** — 13 new unit tests for nested field constraint parsing/evaluation
- **`pkg/handler/eval_test.go`** — 5 new integration tests for nested entity context evaluation

### Documentation
- **`docs/flagr_overview.md`** — constraint section updated with nested field syntax examples
- **`swagger/index.yaml`** — `property` field descriptions added for `constraint` and `createConstraintRequest`

### UI
- **No changes needed** — the Property field is a plain text input; users can type `user.name` etc. directly
- All operators already supported in the dropdown

## Backward Compatibility
- Simple flat properties like `state`, `age`, `dl_state` continue to work exactly as before
- The old `{a}{b}` key composition syntax still works for flat dotted keys