### PR TITLE
fix: use regex literal form for EREG/NEREG + upgrade conditions to v0.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/urfave/negroni v1.0.0
 	github.com/yadvendar/negroni-newrelic-go-agent v0.0.0-20160803090806-3dc58758cb67
-	github.com/zhouzhuojie/conditions v0.2.5
+	github.com/zhouzhuojie/conditions v0.2.6
 	github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5
 	golang.org/x/net v0.48.0
 	google.golang.org/api v0.257.0

--- a/go.sum
+++ b/go.sum
@@ -430,6 +430,8 @@ github.com/zhouzhuojie/conditions v0.2.4 h1:mgrhd6uA9befUchbvrmekohWk+9waGsUr2WS
 github.com/zhouzhuojie/conditions v0.2.4/go.mod h1:fSgYEsOx1XDtsXWYM9lJkn3XTU73xsso3as8Yhqmaz0=
 github.com/zhouzhuojie/conditions v0.2.5 h1:xLLZ47yOk7UuJPVXsllNYes6/N36DIoEJiWi4h/xIew=
 github.com/zhouzhuojie/conditions v0.2.5/go.mod h1:fSgYEsOx1XDtsXWYM9lJkn3XTU73xsso3as8Yhqmaz0=
+github.com/zhouzhuojie/conditions v0.2.6 h1:bx5mz9rzrQkqbLw1y+oMpgfNaG553Ze5YLkHf3kZBX0=
+github.com/zhouzhuojie/conditions v0.2.6/go.mod h1:fSgYEsOx1XDtsXWYM9lJkn3XTU73xsso3as8Yhqmaz0=
 github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5 h1:YuR5otuPvpk6EPrKy9rVXiQKTqgY6OEqSlzko9kcfCI=
 github.com/zhouzhuojie/withtimeout v0.0.0-20190405051827-12b39eb2edd5/go.mod h1:nhm/3zpPm56iKoXLEeeevuI5V9qEtNhuhLbPZwcrgcs=
 go.einride.tech/aip v0.73.0 h1:bPo4oqBo2ZQeBKo4ZzLb1kxYXTY1ysJhpvQyfuGzvps=

--- a/pkg/entity/constraint.go
+++ b/pkg/entity/constraint.go
@@ -47,7 +47,7 @@ func (c *Constraint) ToExpr() (conditions.Expr, error) {
 	p := conditions.NewParser(strings.NewReader(s))
 	expr, err := p.Parse()
 	if err != nil {
-		return nil, fmt.Errorf("%s. Note: if it's string or array of string, warp it with quotes \"...\"", err)
+		return nil, fmt.Errorf("%s. Note: if it's string or array of string, wrap it with quotes \"...\" For regex patterns, use a quoted string with Go regexp syntax (e.g. \"\\d+\" for digits)", err)
 	}
 	return expr, nil
 }
@@ -66,7 +66,30 @@ func (c *Constraint) toExprStr() (string, error) {
 		return "", fmt.Errorf("not supported operator: %s", c.Operator)
 	}
 
-	return fmt.Sprintf("({%s} %s %s)", c.Property, o, c.Value), nil
+	// Trim the value to be resilient against untrimmed values from API callers.
+	val := strings.TrimSpace(c.Value)
+
+	// For EREG/NEREG with quoted string values, use regex literal form /pattern/
+	// to avoid Go text/scanner escape issues with sequences like \d, \., \s, etc.
+	// The scanner interprets escape sequences inside quoted strings and rejects
+	// unrecognized ones (like \., \d), but regex literals are read character-by-character
+	// without escape processing, so patterns with backslashes work correctly.
+	if (c.Operator == models.ConstraintOperatorEREG || c.Operator == models.ConstraintOperatorNEREG) &&
+		isQuotedString(val) {
+		pattern := val[1 : len(val)-1]
+		// Only use regex literal form when the pattern doesn't contain "/",
+		// because the conditions parser doesn't support escaping "/" inside //.
+		if !strings.Contains(pattern, "/") {
+			return fmt.Sprintf("({%s} %s /%s/)", c.Property, o, pattern), nil
+		}
+	}
+
+	return fmt.Sprintf("({%s} %s %s)", c.Property, o, val), nil
+}
+
+// isQuotedString reports whether s is a double-quoted string like "foo".
+func isQuotedString(s string) bool {
+	return len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"'
 }
 
 // Validate validates Constraint
@@ -89,7 +112,7 @@ func (cs ConstraintArray) ToExpr() (conditions.Expr, error) {
 	p := conditions.NewParser(strings.NewReader(exprStr))
 	expr, err := p.Parse()
 	if err != nil {
-		return nil, fmt.Errorf("%s. Note: if it's string or array of string, wrap it with quotes \"...\"", err)
+		return nil, fmt.Errorf("%s. Note: if it's string or array of string, wrap it with quotes \"...\" For regex patterns, use a quoted string with Go regexp syntax (e.g. \"\\d+\" for digits)", err)
 	}
 	return expr, nil
 }

--- a/pkg/entity/constraint_test.go
+++ b/pkg/entity/constraint_test.go
@@ -386,3 +386,215 @@ func TestConstraintToExpr_NestedField(t *testing.T) {
 		assert.False(t, match)
 	})
 }
+
+func TestConstraintToExpr_RegexEscaping(t *testing.T) {
+	// EREG with backslash sequences (the main fix)
+	// These previously caused Go scanner "invalid char escape" errors
+	t.Run("EREG with \\d pattern", func(t *testing.T) {
+		c := Constraint{
+			Property: "status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"\d+"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"status": "123"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+		match, err = conditions.Evaluate(expr, map[string]any{"status": "abc"})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("EREG with \\. pattern (literal dot)", func(t *testing.T) {
+		c := Constraint{
+			Property: "email",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `".+@example\.com"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"email": "user@example.com"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+		match, err = conditions.Evaluate(expr, map[string]any{"email": "user@exampleXcom"})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("EREG with \\w pattern (word chars)", func(t *testing.T) {
+		c := Constraint{
+			Property: "name",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"\w+"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"name": "hello"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+		match, err = conditions.Evaluate(expr, map[string]any{"name": "!!!"})
+		assert.NoError(t, err)
+		assert.False(t, match) // no word chars, \w+ has nothing to match
+	})
+
+	t.Run("EREG with \\s pattern (whitespace)", func(t *testing.T) {
+		c := Constraint{
+			Property: "text",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"hello\sworld"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"text": "hello world"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("EREG with \\b pattern (word boundary)", func(t *testing.T) {
+		c := Constraint{
+			Property: "text",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"\bword\b"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"text": "word"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// NEREG with backslash sequences
+	t.Run("NEREG with \\d pattern", func(t *testing.T) {
+		c := Constraint{
+			Property: "status",
+			Operator: models.ConstraintOperatorNEREG,
+			Value:    `"\d+"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"status": "abc"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+		match, err = conditions.Evaluate(expr, map[string]any{"status": "123"})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	// Simple regex without backslashes should still work (regression check)
+	t.Run("EREG simple pattern without backslash", func(t *testing.T) {
+		c := Constraint{
+			Property: "status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"^5[0-9][0-9]$"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"status": "500"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// Regex literal form (starts with /) should be unchanged
+	t.Run("EREG with regex literal form", func(t *testing.T) {
+		c := Constraint{
+			Property: "status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `/^5[0-9][0-9]$/`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"status": "500"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// Pattern containing "/" falls back to string form
+	t.Run("EREG with pattern containing slash", func(t *testing.T) {
+		c := Constraint{
+			Property: "path",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `"/api/v1/.+"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"path": "/api/v1/users"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// Variable reference as value (unchanged)
+	t.Run("EREG with var ref value", func(t *testing.T) {
+		c := Constraint{
+			Property: "status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `{pattern}`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"status":  "123",
+			"pattern": `\d+`,
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// Trimmed value handling
+	t.Run("EREG with trimmed value containing spaces", func(t *testing.T) {
+		c := Constraint{
+			Property: "status",
+			Operator: models.ConstraintOperatorEREG,
+			Value:    `  "\d+"  `,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"status": "123"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// Non-EREG operator should be unaffected
+	t.Run("EQ operator unaffected by regex fix", func(t *testing.T) {
+		c := Constraint{
+			Property: "name",
+			Operator: models.ConstraintOperatorEQ,
+			Value:    `"Alice"`,
+		}
+		expr, err := c.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{"name": "Alice"})
+		assert.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	// Multiple constraints with regex in ConstraintArray
+	t.Run("ConstraintArray with regex patterns", func(t *testing.T) {
+		cs := ConstraintArray{
+			{
+				Property: "email",
+				Operator: models.ConstraintOperatorEREG,
+				Value:    `".+@example\.com"`,
+			},
+			{
+				Property: "status",
+				Operator: models.ConstraintOperatorEREG,
+				Value:    `"\d+"`,
+			},
+		}
+		expr, err := cs.ToExpr()
+		assert.NoError(t, err)
+		match, err := conditions.Evaluate(expr, map[string]any{
+			"email":  "user@example.com",
+			"status": "200",
+		})
+		assert.NoError(t, err)
+		assert.True(t, match)
+		match, err = conditions.Evaluate(expr, map[string]any{
+			"email":  "user@example.com",
+			"status": "abc",
+		})
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+}


### PR DESCRIPTION
## What

Two changes:

### 1. Flagr: regex literal form for EREG/NEREG

For **EREG/NEREG** operators with quoted string values (e.g. `"\d+"`), `toExprStr()` now outputs the **regex literal form** `/pattern/` instead of `"pattern"` when the pattern doesn't contain `/`:

| Before | After |
|---|---|
| `({s} =~ "\d+")` ❌ scanner error | `({s} =~ /\d+/)` ✅ |
| `({email} =~ ".+@example\.com")` ❌ | `({email} =~ /.+@example\.com/)` ✅ |

This eliminates Go `text/scanner` "invalid char escape" stderr noise.

### 2. Upgrade: conditions v0.2.6

Pulls in the `strconv.Unquote` fix for the conditions parser, enabling correct matching on values containing `"` and `\`:

| Expression | Before | After |
|---|---|---|
| `{s} == "he said \"hey\""` | ❌ `\"` treated as 2 raw bytes | ✅ Unescaped to `"` |
| `{s} == "path\\to\\file"` | ❌ `\\` treated as 2 raw bytes | ✅ Unescaped to `\` |
| `{s} =~ "\d+"` (invalid Go escape) | ⚠️ Raw fallback (noisy) | ✅ Same fallback (unchanged) |

## Tests

13 new subtests for the Flagr-side regex fix + conditions v0.2.6 includes 14 escape sequence tests.

Closes #618
