### PR TITLE
perf: short-circuit EvalCache reload when no new flag_snapshot

### DIFF
--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -45,8 +45,8 @@ The definitions of the following concepts are in [API doc](https://openflagr.git
 
 There are three components in the flagr, Flagr Evaluator, Flagr Manager, and Flagr Metrics.
 
-- Flagr Evaluator. Flagr evaluator evaluates the incoming requests.
-- Flagr Manager. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
-- Flagr Metrics. Flagr metrics is the data pipeline to collect evaluation results. Currently Flagr only supports Kafka as the pipeline.
+- **Flagr Evaluator**. Flagr evaluator evaluates the incoming requests. It maintains an in-memory cache (`EvalCache`) of all flags, segments, variants, constraints, distributions, and tags — pre-parsed and ready for fast evaluation. The cache is refreshed periodically (default every 3s, configurable via `FLAGR_EVALCACHE_REFRESHINTERVAL`). To avoid unnecessary database load, the reload short-circuits when no new `flag_snapshot` rows have been created, since every mutation handler that affects evaluation data also creates a snapshot.
+- **Flagr Manager**. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
+- **Flagr Metrics**. Flagr metrics is the data pipeline to collect evaluation results. Currently Flagr only supports Kafka as the pipeline.
 
 ![Flagr Architecture](images/flagr_arch.png)

--- a/docs/flagr_overview.md
+++ b/docs/flagr_overview.md
@@ -45,8 +45,8 @@ The definitions of the following concepts are in [API doc](https://openflagr.git
 
 There are three components in the flagr, Flagr Evaluator, Flagr Manager, and Flagr Metrics.
 
-- **Flagr Evaluator**. Flagr evaluator evaluates the incoming requests. It maintains an in-memory cache (`EvalCache`) of all flags, segments, variants, constraints, distributions, and tags — pre-parsed and ready for fast evaluation. The cache is refreshed periodically (default every 3s, configurable via `FLAGR_EVALCACHE_REFRESHINTERVAL`). To avoid unnecessary database load, the reload short-circuits when no new `flag_snapshot` rows have been created, since every mutation handler that affects evaluation data also creates a snapshot.
-- **Flagr Manager**. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
-- **Flagr Metrics**. Flagr metrics is the data pipeline to collect evaluation results. Currently Flagr only supports Kafka as the pipeline.
+- Flagr Evaluator. Flagr evaluator evaluates the incoming requests.
+- Flagr Manager. Flagr manager is the CRUD gateway. All the mutations of flags happen here.
+- Flagr Metrics. Flagr metrics is the data pipeline to collect evaluation results. Currently Flagr only supports Kafka as the pipeline.
 
 ![Flagr Architecture](images/flagr_arch.png)

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -32,6 +32,12 @@ type EvalCache struct {
 	cacheMutex      sync.RWMutex
 	refreshTimeout  time.Duration
 	refreshInterval time.Duration
+
+	// lastSnapshotMaxID tracks the highest flag_snapshot ID seen on the last
+	// successful reload. The cache short-circuits when this hasn't changed,
+	// because every API mutation that affects eval data creates a snapshot.
+	// lastSnapshotMaxID > 0 indicates at least one successful load has occurred.
+	lastSnapshotMaxID uint
 }
 
 // GetEvalCache gets the EvalCache
@@ -144,9 +150,26 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
+// reloadMapCache reloads the evaluation cache from the database. It short-circuits
+// when no new flag_snapshots have been created, since every API mutation that
+// affects evaluation data (flags, segments, variants, constraints, distributions,
+// tags) creates a flag_snapshot row.
 func (ec *EvalCache) reloadMapCache() error {
 	if config.Config.NewRelicEnabled {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
+	}
+
+	// Lightweight check: has any evaluation data changed since last reload?
+	// Every mutation handler that affects the cache creates a flag_snapshot,
+	// so a rising MAX(id) means the cache is stale.
+	var currentMaxID uint
+	if err := getDB().Model(&entity.FlagSnapshot{}).
+		Select("COALESCE(MAX(id), 0)").
+		Scan(&currentMaxID).Error; err != nil {
+		logrus.WithField("err", err).Warn(
+			"failed to query flag_snapshots MAX(id), falling back to full reload")
+	} else if currentMaxID == ec.lastSnapshotMaxID && ec.lastSnapshotMaxID > 0 {
+		return nil
 	}
 
 	_, _, err := withtimeout.Do(ec.refreshTimeout, func() (any, error) {
@@ -163,8 +186,12 @@ func (ec *EvalCache) reloadMapCache() error {
 		}
 		ec.cacheMutex.Unlock()
 
-		return nil, err
+		return nil, nil
 	})
+
+	if err == nil {
+		ec.lastSnapshotMaxID = currentMaxID
+	}
 
 	return err
 }

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -32,12 +32,6 @@ type EvalCache struct {
 	cacheMutex      sync.RWMutex
 	refreshTimeout  time.Duration
 	refreshInterval time.Duration
-
-	// lastSnapshotMaxID tracks the highest flag_snapshot ID seen on the last
-	// successful reload. The cache short-circuits when this hasn't changed,
-	// because every API mutation that affects eval data creates a snapshot.
-	// lastSnapshotMaxID > 0 indicates at least one successful load has occurred.
-	lastSnapshotMaxID uint
 }
 
 // GetEvalCache gets the EvalCache
@@ -150,26 +144,9 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
-// reloadMapCache reloads the evaluation cache from the database. It short-circuits
-// when no new flag_snapshots have been created, since every API mutation that
-// affects evaluation data (flags, segments, variants, constraints, distributions,
-// tags) creates a flag_snapshot row.
 func (ec *EvalCache) reloadMapCache() error {
 	if config.Config.NewRelicEnabled {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
-	}
-
-	// Lightweight check: has any evaluation data changed since last reload?
-	// Every mutation handler that affects the cache creates a flag_snapshot,
-	// so a rising MAX(id) means the cache is stale.
-	var currentMaxID uint
-	if err := getDB().Model(&entity.FlagSnapshot{}).
-		Select("COALESCE(MAX(id), 0)").
-		Scan(&currentMaxID).Error; err != nil {
-		logrus.WithField("err", err).Warn(
-			"failed to query flag_snapshots MAX(id), falling back to full reload")
-	} else if currentMaxID == ec.lastSnapshotMaxID && ec.lastSnapshotMaxID > 0 {
-		return nil
 	}
 
 	_, _, err := withtimeout.Do(ec.refreshTimeout, func() (any, error) {
@@ -186,12 +163,8 @@ func (ec *EvalCache) reloadMapCache() error {
 		}
 		ec.cacheMutex.Unlock()
 
-		return nil, nil
+		return nil, err
 	})
-
-	if err == nil {
-		ec.lastSnapshotMaxID = currentMaxID
-	}
 
 	return err
 }

--- a/pkg/handler/eval_cache_test.go
+++ b/pkg/handler/eval_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openflagr/flagr/pkg/entity"
+	"github.com/openflagr/flagr/pkg/notification"
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,7 @@ func TestGetByFlagKeyOrID(t *testing.T) {
 	defer gostub.StubFunc(&getDB, db).Reset()
 
 	ec := GetEvalCache()
+	ec.lastSnapshotMaxID = 0
 	ec.reloadMapCache()
 	f := ec.GetByFlagKeyOrID(fixtureFlag.ID)
 	assert.Equal(t, f.ID, fixtureFlag.ID)
@@ -42,6 +44,7 @@ func TestGetByTags(t *testing.T) {
 	defer gostub.StubFunc(&getDB, db).Reset()
 
 	ec := GetEvalCache()
+	ec.lastSnapshotMaxID = 0
 	ec.reloadMapCache()
 
 	tags := make([]string, len(fixtureFlag.Tags))
@@ -70,4 +73,55 @@ func TestGetByTags(t *testing.T) {
 
 	f = ec.GetByTags(tags, &all)
 	assert.Len(t, f, 0)
+}
+
+func TestReloadMapCacheShortCircuit(t *testing.T) {
+	fixtureFlag := entity.GenFixtureFlag()
+	db := entity.PopulateTestDB(fixtureFlag)
+
+	tmpDB, dbErr := db.DB()
+	if dbErr != nil {
+		t.Fatalf("Failed to get database")
+	}
+	defer tmpDB.Close()
+	defer gostub.StubFunc(&getDB, db).Reset()
+
+	// Create an initial snapshot so MAX(id) > 0 and the short-circuit
+	// guard (lastSnapshotMaxID > 0) can engage.
+	entity.SaveFlagSnapshot(db, fixtureFlag.ID, "test",
+		notification.OperationCreate, notification.ComponentFlag, fixtureFlag.ID, fixtureFlag.Key)
+
+	ec := GetEvalCache()
+	ec.lastSnapshotMaxID = 0
+
+	// Wrap fetchAllFlags to count how many times it's called.
+	fetchCount := 0
+	origFetch := fetchAllFlags
+	fetchAllFlags = func() ([]entity.Flag, error) {
+		fetchCount++
+		return origFetch()
+	}
+	defer func() { fetchAllFlags = origFetch }()
+
+	// 1st call: must fetch (no prior MAX id tracked).
+	err := ec.reloadMapCache()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, fetchCount, "first call should fetch full data")
+	assert.Greater(t, ec.lastSnapshotMaxID, uint(0), "should track snapshot max ID")
+
+	// 2nd call: must short-circuit (no new snapshot created).
+	err = ec.reloadMapCache()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, fetchCount, "second call should short-circuit")
+	assert.Equal(t, ec.lastSnapshotMaxID, ec.lastSnapshotMaxID,
+		"snapshot max ID must not change when no new snapshot exists")
+
+	// Create another snapshot to simulate a mutation via the API.
+	entity.SaveFlagSnapshot(db, fixtureFlag.ID, "test",
+		notification.OperationUpdate, notification.ComponentFlag, fixtureFlag.ID, fixtureFlag.Key)
+
+	// 3rd call: must fetch again (new snapshot invalidated the cache).
+	err = ec.reloadMapCache()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, fetchCount, "third call should fetch (new snapshot)")
 }

--- a/pkg/handler/eval_cache_test.go
+++ b/pkg/handler/eval_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/openflagr/flagr/pkg/entity"
-	"github.com/openflagr/flagr/pkg/notification"
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +23,6 @@ func TestGetByFlagKeyOrID(t *testing.T) {
 	defer gostub.StubFunc(&getDB, db).Reset()
 
 	ec := GetEvalCache()
-	ec.lastSnapshotMaxID = 0
 	ec.reloadMapCache()
 	f := ec.GetByFlagKeyOrID(fixtureFlag.ID)
 	assert.Equal(t, f.ID, fixtureFlag.ID)
@@ -44,7 +42,6 @@ func TestGetByTags(t *testing.T) {
 	defer gostub.StubFunc(&getDB, db).Reset()
 
 	ec := GetEvalCache()
-	ec.lastSnapshotMaxID = 0
 	ec.reloadMapCache()
 
 	tags := make([]string, len(fixtureFlag.Tags))
@@ -73,55 +70,4 @@ func TestGetByTags(t *testing.T) {
 
 	f = ec.GetByTags(tags, &all)
 	assert.Len(t, f, 0)
-}
-
-func TestReloadMapCacheShortCircuit(t *testing.T) {
-	fixtureFlag := entity.GenFixtureFlag()
-	db := entity.PopulateTestDB(fixtureFlag)
-
-	tmpDB, dbErr := db.DB()
-	if dbErr != nil {
-		t.Fatalf("Failed to get database")
-	}
-	defer tmpDB.Close()
-	defer gostub.StubFunc(&getDB, db).Reset()
-
-	// Create an initial snapshot so MAX(id) > 0 and the short-circuit
-	// guard (lastSnapshotMaxID > 0) can engage.
-	entity.SaveFlagSnapshot(db, fixtureFlag.ID, "test",
-		notification.OperationCreate, notification.ComponentFlag, fixtureFlag.ID, fixtureFlag.Key)
-
-	ec := GetEvalCache()
-	ec.lastSnapshotMaxID = 0
-
-	// Wrap fetchAllFlags to count how many times it's called.
-	fetchCount := 0
-	origFetch := fetchAllFlags
-	fetchAllFlags = func() ([]entity.Flag, error) {
-		fetchCount++
-		return origFetch()
-	}
-	defer func() { fetchAllFlags = origFetch }()
-
-	// 1st call: must fetch (no prior MAX id tracked).
-	err := ec.reloadMapCache()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, fetchCount, "first call should fetch full data")
-	assert.Greater(t, ec.lastSnapshotMaxID, uint(0), "should track snapshot max ID")
-
-	// 2nd call: must short-circuit (no new snapshot created).
-	err = ec.reloadMapCache()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, fetchCount, "second call should short-circuit")
-	assert.Equal(t, ec.lastSnapshotMaxID, ec.lastSnapshotMaxID,
-		"snapshot max ID must not change when no new snapshot exists")
-
-	// Create another snapshot to simulate a mutation via the API.
-	entity.SaveFlagSnapshot(db, fixtureFlag.ID, "test",
-		notification.OperationUpdate, notification.ComponentFlag, fixtureFlag.ID, fixtureFlag.Key)
-
-	// 3rd call: must fetch again (new snapshot invalidated the cache).
-	err = ec.reloadMapCache()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, fetchCount, "third call should fetch (new snapshot)")
 }

--- a/pkg/handler/export_test.go
+++ b/pkg/handler/export_test.go
@@ -150,6 +150,7 @@ func TestExportEvalCacheJSONHandler(t *testing.T) {
 	defer gostub.StubFunc(&getDB, db).Reset()
 
 	ec := GetEvalCache()
+	ec.lastSnapshotMaxID = 0
 	ec.reloadMapCache()
 
 	t.Run("happy code path", func(t *testing.T) {

--- a/pkg/handler/export_test.go
+++ b/pkg/handler/export_test.go
@@ -150,7 +150,6 @@ func TestExportEvalCacheJSONHandler(t *testing.T) {
 	defer gostub.StubFunc(&getDB, db).Reset()
 
 	ec := GetEvalCache()
-	ec.lastSnapshotMaxID = 0
 	ec.reloadMapCache()
 
 	t.Run("happy code path", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`EvalCache.reloadMapCache()` runs every 3 seconds by default and unconditionally performs a **full eager-load** of all flags (with segments, variants, constraints, distributions, and tags) from the database — even when zero data has changed. At scale, this creates unnecessary database load, CPU/memory churn from deserialization and constraint parsing, and GC pressure.

## Solution

Short-circuit the full reload by checking whether any new `flag_snapshot` rows have been created since the last load. Every CRUD mutation that affects evaluation data creates a flag snapshot, so `SELECT MAX(id) FROM flag_snapshots` is a reliable change indicator.

### Coverage verification

Every mutation handler that affects the eval cache calls `entity.SaveFlagSnapshot(...)`:

| Handler | Operation | Snapshot created? |
|---|---|---|
| `CreateFlag` / `PutFlag` / `SetFlagEnabledState` | Flag CRUD | ✅ |
| `DeleteFlag` / `RestoreFlag` | Flag delete/restore | ✅ |
| `CreateTag` / `DeleteTag` | Tag association | ✅ |
| `CreateSegment` / `PutSegment` / `PutSegmentsReorder` | Segment CRUD | ✅ |
| `DeleteSegment` | Segment soft delete | ✅ |
| `CreateConstraint` / `PutConstraint` / `DeleteConstraint` | Constraint CRUD | ✅ |
| `PutDistributions` | Distribution batch update | ✅ |
| `CreateVariant` / `PutVariant` / `DeleteVariant` | Variant CRUD | ✅ |

18 mutation handlers total — all create a snapshot. Tag association changes (hard deletes from the `flags_tags` join table) are also covered since `DeleteTag` calls `SaveFlagSnapshot`.

### What about soft deletes?

Soft-deletes set `deleted_at` without bumping `updated_at` on the parent entity, but `SaveFlagSnapshot` is always called after the delete, so `MAX(id)` on `flag_snapshots` still increments.

### What about future model changes?

If someone adds a new entity that affects evaluation data, the corresponding handler should call `SaveFlagSnapshot` (which is already the established convention for the existing 18 handlers). If it does not, the cache will not detect the change — same as if they bypass `SaveFlagSnapshot` for any existing handler. The startup self-check (querying DB metadata for all table names) is not part of this PR but could be added separately.

## Changes

- **`pkg/handler/eval_cache.go`** — Added `lastSnapshotMaxID uint` field to `EvalCache`. In `reloadMapCache()`, run a lightweight `SELECT COALESCE(MAX(id), 0) FROM flag_snapshots` via GORM before the full fetch. Short-circuit when it has not changed.
- **`pkg/handler/eval_cache_test.go`** — Added `TestReloadMapCacheShortCircuit` that verifies the fetch is skipped on repeated calls and re-enabled after a new snapshot. Existing tests reset `lastSnapshotMaxID` to ensure they always load.
- **`pkg/handler/export_test.go`** — Same reset for the singleton.
- **`docs/flagr_overview.md`** — Documented the EvalCache and its short-circuit behavior in the Architecture section.

## Performance

Before: full multi-join eager load of every flag every 3s.
After: one primary-key index lookup (`MAX(id)`) per tick. At ~1ms per query, this is negligible.
