### PR TITLE
refactor: extract shortCircuitReload and protect lastSnapshotMaxID with mutex

### DIFF
--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,27 +150,29 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
-// shouldSkipReload queries flag_snapshots MAX(id) and compares it against
-// the last known value. Returns (true, 0) when the cache is still fresh and
-// no full reload is needed. Returns (false, maxID) when a reload is needed.
-func (ec *EvalCache) shouldSkipReload() (bool, uint) {
-	var currentMaxID uint
+// reloadRequired checks whether a full cache reload is needed by comparing
+// the current flag_snapshot MAX(id) against the last known value.
+// Returns (true, maxIDFromDB) when a reload is needed, or (false, 0) when
+// the cache is still fresh.
+func (ec *EvalCache) reloadRequired() (bool, uint) {
+	var maxIDFromDB uint
 	if err := getDB().Model(&entity.FlagSnapshot{}).
 		Select("COALESCE(MAX(id), 0)").
-		Scan(&currentMaxID).Error; err != nil {
+		Scan(&maxIDFromDB).Error; err != nil {
 		logrus.WithField("err", err).Warn(
 			"failed to query flag_snapshots MAX(id), falling back to full reload")
-		return false, 0
+		return true, 0
 	}
 
 	ec.cacheMutex.RLock()
-	saved := ec.lastSnapshotMaxID
+	maxIDFromCache := ec.lastSnapshotMaxID
 	ec.cacheMutex.RUnlock()
 
-	if currentMaxID == saved && saved > 0 {
-		return true, 0
+	// No new snapshot since last reload, and we have loaded at least once.
+	if maxIDFromDB == maxIDFromCache && maxIDFromCache > 0 {
+		return false, 0
 	}
-	return false, currentMaxID
+	return true, maxIDFromDB
 }
 
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
@@ -182,8 +184,8 @@ func (ec *EvalCache) reloadMapCache() error {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
 	}
 
-	skip, currentMaxID := ec.shouldSkipReload()
-	if skip {
+	needed, currentMaxID := ec.reloadRequired()
+	if !needed {
 		return nil
 	}
 

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,29 +150,25 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
-// reloadRequired checks whether a full cache reload is needed by comparing
-// the current flag_snapshot MAX(id) against the last known value.
-// Returns (true, maxIDFromDB) when a reload is needed, or (false, 0) when
-// the cache is still fresh.
-func (ec *EvalCache) reloadRequired() (bool, uint) {
+// shortCircuitReload queries flag_snapshots MAX(id) and compares it
+// against the last known value. Returns (true, maxIDFromDB) when the
+// cache is still fresh and the reload can be short-circuited, or
+// (false, maxIDFromDB) when a full reload is needed. On query error
+// it conservatively returns (false, 0) to trigger a reload.
+func (ec *EvalCache) shortCircuitReload() (bool, uint) {
 	var maxIDFromDB uint
 	if err := getDB().Model(&entity.FlagSnapshot{}).
 		Select("COALESCE(MAX(id), 0)").
 		Scan(&maxIDFromDB).Error; err != nil {
 		logrus.WithField("err", err).Warn(
 			"failed to query flag_snapshots MAX(id), falling back to full reload")
-		return true, 0
+		return false, 0
 	}
 
 	ec.cacheMutex.RLock()
-	maxIDFromCache := ec.lastSnapshotMaxID
-	ec.cacheMutex.RUnlock()
-
-	// No new snapshot since last reload, and we have loaded at least once.
-	if maxIDFromDB == maxIDFromCache && maxIDFromCache > 0 {
-		return false, 0
-	}
-	return true, maxIDFromDB
+	defer ec.cacheMutex.RUnlock()
+	skip := ec.lastSnapshotMaxID == maxIDFromDB && ec.lastSnapshotMaxID > 0
+	return skip, maxIDFromDB
 }
 
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
@@ -184,8 +180,8 @@ func (ec *EvalCache) reloadMapCache() error {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
 	}
 
-	needed, currentMaxID := ec.reloadRequired()
-	if !needed {
+	skip, maxIDFromDB := ec.shortCircuitReload()
+	if skip {
 		return nil
 	}
 
@@ -201,7 +197,7 @@ func (ec *EvalCache) reloadMapCache() error {
 			keyCache: keyCache,
 			tagCache: tagCache,
 		}
-		ec.lastSnapshotMaxID = currentMaxID
+		ec.lastSnapshotMaxID = maxIDFromDB
 		ec.cacheMutex.Unlock()
 
 		return nil, nil

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,29 +150,27 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
-// readSnapshotMaxID queries the highest flag_snapshot id. Returns 0 on error
-// (with a warning logged). This is the lightweight change indicator used to
-// short-circuit full cache reloads.
-func (ec *EvalCache) readSnapshotMaxID() uint {
+// shouldSkipReload queries flag_snapshots MAX(id) and compares it against
+// the last known value. Returns (true, 0) when the cache is still fresh and
+// no full reload is needed. Returns (false, maxID) when a reload is needed.
+func (ec *EvalCache) shouldSkipReload() (bool, uint) {
 	var currentMaxID uint
 	if err := getDB().Model(&entity.FlagSnapshot{}).
 		Select("COALESCE(MAX(id), 0)").
 		Scan(&currentMaxID).Error; err != nil {
 		logrus.WithField("err", err).Warn(
 			"failed to query flag_snapshots MAX(id), falling back to full reload")
+		return false, 0
 	}
-	return currentMaxID
-}
 
-// shouldSkipReload compares currentMaxID with the last known snapshot ID.
-// Returns true when the cache is still fresh and no full reload is needed.
-// This is a pure-logic helper (no I/O) and is trivially testable.
-func (ec *EvalCache) shouldSkipReload(currentMaxID uint) bool {
 	ec.cacheMutex.RLock()
 	saved := ec.lastSnapshotMaxID
 	ec.cacheMutex.RUnlock()
 
-	return currentMaxID == saved && saved > 0
+	if currentMaxID == saved && saved > 0 {
+		return true, 0
+	}
+	return false, currentMaxID
 }
 
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
@@ -184,8 +182,8 @@ func (ec *EvalCache) reloadMapCache() error {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
 	}
 
-	currentMaxID := ec.readSnapshotMaxID()
-	if ec.shouldSkipReload(currentMaxID) {
+	skip, currentMaxID := ec.shouldSkipReload()
+	if skip {
 		return nil
 	}
 

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,6 +150,20 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
+// readSnapshotMaxID queries the highest flag_snapshot id. Returns 0 on error
+// (with a warning logged). This is the lightweight change indicator used to
+// short-circuit full cache reloads.
+func (ec *EvalCache) readSnapshotMaxID() uint {
+	var currentMaxID uint
+	if err := getDB().Model(&entity.FlagSnapshot{}).
+		Select("COALESCE(MAX(id), 0)").
+		Scan(&currentMaxID).Error; err != nil {
+		logrus.WithField("err", err).Warn(
+			"failed to query flag_snapshots MAX(id), falling back to full reload")
+	}
+	return currentMaxID
+}
+
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
 // when no new flag_snapshots have been created, since every API mutation that
 // affects evaluation data (flags, segments, variants, constraints, distributions,
@@ -159,25 +173,16 @@ func (ec *EvalCache) reloadMapCache() error {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
 	}
 
-	// Lightweight check: has any evaluation data changed since last reload?
-	// Every mutation handler that affects the cache creates a flag_snapshot,
-	// so a rising MAX(id) means the cache is stale.
-	var currentMaxID uint
-	if err := getDB().Model(&entity.FlagSnapshot{}).
-		Select("COALESCE(MAX(id), 0)").
-		Scan(&currentMaxID).Error; err != nil {
-		logrus.WithField("err", err).Warn(
-			"failed to query flag_snapshots MAX(id), falling back to full reload")
-	} else {
-		// Protect the read so this is safe if reloadMapCache is ever
-		// called from multiple goroutines.
-		ec.cacheMutex.RLock()
-		savedMaxID := ec.lastSnapshotMaxID
-		ec.cacheMutex.RUnlock()
+	currentMaxID := ec.readSnapshotMaxID()
 
-		if currentMaxID == savedMaxID && savedMaxID > 0 {
-			return nil
-		}
+	ec.cacheMutex.RLock()
+	saved := ec.lastSnapshotMaxID
+	ec.cacheMutex.RUnlock()
+
+	// Short-circuit when no new snapshot exists. On the first load (saved == 0)
+	// we always proceed to populate the cache.
+	if currentMaxID == saved && saved > 0 {
+		return nil
 	}
 
 	_, _, err := withtimeout.Do(ec.refreshTimeout, func() (any, error) {

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,18 +150,25 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
+// snapshotMaxID queries the latest flag_snapshot id. Returns 0 on error.
+// This is the lightweight change indicator used by the EvalCache to decide
+// whether a full reload is needed.
+func (ec *EvalCache) snapshotMaxID() uint {
+	var maxID uint
+	if err := getDB().Model(&entity.FlagSnapshot{}).
+		Select("COALESCE(MAX(id), 0)").
+		Scan(&maxID).Error; err != nil {
+		logrus.WithField("err", err).Warn(
+			"failed to query flag_snapshots MAX(id), falling back to full reload")
+	}
+	return maxID
+}
+
 // shortCircuitReload checks whether the cache is still fresh by comparing
 // the current flag_snapshot MAX(id) against the last known value.
 // Returns true when the reload can be skipped.
 func (ec *EvalCache) shortCircuitReload() bool {
-	var maxIDFromDB uint
-	if err := getDB().Model(&entity.FlagSnapshot{}).
-		Select("COALESCE(MAX(id), 0)").
-		Scan(&maxIDFromDB).Error; err != nil {
-		logrus.WithField("err", err).Warn(
-			"failed to query flag_snapshots MAX(id), falling back to full reload")
-		return false
-	}
+	maxIDFromDB := ec.snapshotMaxID()
 
 	ec.cacheMutex.RLock()
 	defer ec.cacheMutex.RUnlock()
@@ -189,10 +196,7 @@ func (ec *EvalCache) reloadMapCache() error {
 
 		// Query MAX(id) right after the data fetch so that the stored
 		// snapshot ID tracks the data as closely as possible.
-		var maxIDFromDB uint
-		getDB().Model(&entity.FlagSnapshot{}).
-			Select("COALESCE(MAX(id), 0)").
-			Scan(&maxIDFromDB)
+		maxIDFromDB := ec.snapshotMaxID()
 
 		ec.cacheMutex.Lock()
 		ec.cache = &cacheContainer{

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,10 +150,10 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
-// snapshotMaxID queries the latest flag_snapshot id. Returns 0 on error.
+// getSnapshotMaxID queries the latest flag_snapshot id. Returns 0 on error.
 // This is the lightweight change indicator used by the EvalCache to decide
 // whether a full reload is needed.
-func (ec *EvalCache) snapshotMaxID() uint {
+func (ec *EvalCache) getSnapshotMaxID() uint {
 	var maxID uint
 	if err := getDB().Model(&entity.FlagSnapshot{}).
 		Select("COALESCE(MAX(id), 0)").
@@ -167,12 +167,13 @@ func (ec *EvalCache) snapshotMaxID() uint {
 // shortCircuitReload checks whether the cache is still fresh by comparing
 // the current flag_snapshot MAX(id) against the last known value.
 // Returns true when the reload can be skipped.
-func (ec *EvalCache) shortCircuitReload() bool {
-	maxIDFromDB := ec.snapshotMaxID()
-
+// shortCircuitReload checks whether the cache is still fresh by comparing
+// snapshotMaxID (the current flag_snapshot MAX(id)) against the last known
+// value. Returns true when the reload can be skipped.
+func (ec *EvalCache) shortCircuitReload(snapshotMaxID uint) bool {
 	ec.cacheMutex.RLock()
 	defer ec.cacheMutex.RUnlock()
-	return maxIDFromDB == ec.lastSnapshotMaxID && ec.lastSnapshotMaxID > 0
+	return snapshotMaxID == ec.lastSnapshotMaxID && ec.lastSnapshotMaxID > 0
 }
 
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
@@ -184,7 +185,12 @@ func (ec *EvalCache) reloadMapCache() error {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
 	}
 
-	if ec.shortCircuitReload() {
+	// Read the snapshot ID once, before the fetch. Using this same value
+	// for both the short-circuit decision and the post-reload store guarantees
+	// that lastSnapshotMaxID is never newer than the data in the cache.
+	preFetchMaxID := ec.getSnapshotMaxID()
+
+	if ec.shortCircuitReload(preFetchMaxID) {
 		return nil
 	}
 
@@ -194,17 +200,13 @@ func (ec *EvalCache) reloadMapCache() error {
 			return nil, err
 		}
 
-		// Query MAX(id) right after the data fetch so that the stored
-		// snapshot ID tracks the data as closely as possible.
-		maxIDFromDB := ec.snapshotMaxID()
-
 		ec.cacheMutex.Lock()
 		ec.cache = &cacheContainer{
 			idCache:  idCache,
 			keyCache: keyCache,
 			tagCache: tagCache,
 		}
-		ec.lastSnapshotMaxID = maxIDFromDB
+		ec.lastSnapshotMaxID = preFetchMaxID
 		ec.cacheMutex.Unlock()
 
 		return nil, nil

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -150,25 +150,22 @@ func (ec *EvalCache) GetByFlagKeyOrID(keyOrID any) *entity.Flag {
 	return f
 }
 
-// shortCircuitReload queries flag_snapshots MAX(id) and compares it
-// against the last known value. Returns (true, maxIDFromDB) when the
-// cache is still fresh and the reload can be short-circuited, or
-// (false, maxIDFromDB) when a full reload is needed. On query error
-// it conservatively returns (false, 0) to trigger a reload.
-func (ec *EvalCache) shortCircuitReload() (bool, uint) {
+// shortCircuitReload checks whether the cache is still fresh by comparing
+// the current flag_snapshot MAX(id) against the last known value.
+// Returns true when the reload can be skipped.
+func (ec *EvalCache) shortCircuitReload() bool {
 	var maxIDFromDB uint
 	if err := getDB().Model(&entity.FlagSnapshot{}).
 		Select("COALESCE(MAX(id), 0)").
 		Scan(&maxIDFromDB).Error; err != nil {
 		logrus.WithField("err", err).Warn(
 			"failed to query flag_snapshots MAX(id), falling back to full reload")
-		return false, 0
+		return false
 	}
 
 	ec.cacheMutex.RLock()
 	defer ec.cacheMutex.RUnlock()
-	skip := ec.lastSnapshotMaxID == maxIDFromDB && ec.lastSnapshotMaxID > 0
-	return skip, maxIDFromDB
+	return maxIDFromDB == ec.lastSnapshotMaxID && ec.lastSnapshotMaxID > 0
 }
 
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
@@ -180,8 +177,7 @@ func (ec *EvalCache) reloadMapCache() error {
 		defer config.Global.NewrelicApp.StartTransaction("eval_cache_reload", nil, nil).End()
 	}
 
-	skip, maxIDFromDB := ec.shortCircuitReload()
-	if skip {
+	if ec.shortCircuitReload() {
 		return nil
 	}
 
@@ -190,6 +186,13 @@ func (ec *EvalCache) reloadMapCache() error {
 		if err != nil {
 			return nil, err
 		}
+
+		// Query MAX(id) right after the data fetch so that the stored
+		// snapshot ID tracks the data as closely as possible.
+		var maxIDFromDB uint
+		getDB().Model(&entity.FlagSnapshot{}).
+			Select("COALESCE(MAX(id), 0)").
+			Scan(&maxIDFromDB)
 
 		ec.cacheMutex.Lock()
 		ec.cache = &cacheContainer{

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -168,8 +168,16 @@ func (ec *EvalCache) reloadMapCache() error {
 		Scan(&currentMaxID).Error; err != nil {
 		logrus.WithField("err", err).Warn(
 			"failed to query flag_snapshots MAX(id), falling back to full reload")
-	} else if currentMaxID == ec.lastSnapshotMaxID && ec.lastSnapshotMaxID > 0 {
-		return nil
+	} else {
+		// Protect the read so this is safe if reloadMapCache is ever
+		// called from multiple goroutines.
+		ec.cacheMutex.RLock()
+		savedMaxID := ec.lastSnapshotMaxID
+		ec.cacheMutex.RUnlock()
+
+		if currentMaxID == savedMaxID && savedMaxID > 0 {
+			return nil
+		}
 	}
 
 	_, _, err := withtimeout.Do(ec.refreshTimeout, func() (any, error) {
@@ -184,14 +192,11 @@ func (ec *EvalCache) reloadMapCache() error {
 			keyCache: keyCache,
 			tagCache: tagCache,
 		}
+		ec.lastSnapshotMaxID = currentMaxID
 		ec.cacheMutex.Unlock()
 
 		return nil, nil
 	})
-
-	if err == nil {
-		ec.lastSnapshotMaxID = currentMaxID
-	}
 
 	return err
 }

--- a/pkg/handler/eval_cache.go
+++ b/pkg/handler/eval_cache.go
@@ -164,6 +164,17 @@ func (ec *EvalCache) readSnapshotMaxID() uint {
 	return currentMaxID
 }
 
+// shouldSkipReload compares currentMaxID with the last known snapshot ID.
+// Returns true when the cache is still fresh and no full reload is needed.
+// This is a pure-logic helper (no I/O) and is trivially testable.
+func (ec *EvalCache) shouldSkipReload(currentMaxID uint) bool {
+	ec.cacheMutex.RLock()
+	saved := ec.lastSnapshotMaxID
+	ec.cacheMutex.RUnlock()
+
+	return currentMaxID == saved && saved > 0
+}
+
 // reloadMapCache reloads the evaluation cache from the database. It short-circuits
 // when no new flag_snapshots have been created, since every API mutation that
 // affects evaluation data (flags, segments, variants, constraints, distributions,
@@ -174,14 +185,7 @@ func (ec *EvalCache) reloadMapCache() error {
 	}
 
 	currentMaxID := ec.readSnapshotMaxID()
-
-	ec.cacheMutex.RLock()
-	saved := ec.lastSnapshotMaxID
-	ec.cacheMutex.RUnlock()
-
-	// Short-circuit when no new snapshot exists. On the first load (saved == 0)
-	// we always proceed to populate the cache.
-	if currentMaxID == saved && saved > 0 {
+	if ec.shouldSkipReload(currentMaxID) {
 		return nil
 	}
 


### PR DESCRIPTION
Refactor `reloadMapCache()` by extracting the short-circuit check and fixing a race condition on `lastSnapshotMaxID`.

**Race fix:** `getSnapshotMaxID()` was queried **after** `fetchAllFlags()`. A snapshot created during the fetch would be newer than the cache data, causing the next tick to short-circuit and serve stale data. The fix: query once before the fetch, and use that same value for both the short-circuit decision and the post-reload store.

```go
preFetchMaxID := ec.getSnapshotMaxID()
if ec.shortCircuitReload(preFetchMaxID) {
    return nil
}
// ... fetchAllFlags ...
ec.lastSnapshotMaxID = preFetchMaxID
```

**Mutex protection:** `lastSnapshotMaxID` is now read under `cacheMutex.RLock()` and written under `cacheMutex.Lock()` alongside the `ec.cache` swap.

**Extracted helpers:** `getSnapshotMaxID()` (query), `shortCircuitReload(maxID)` (comparison logic).
