### PR TITLE
Prepare 1.2.4 release

### DIFF
--- a/browser/flagr-ui/package-lock.json
+++ b/browser/flagr-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flagr-ui",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dependencies": {
                 "@element-plus/icons-vue": "^2.3.1",
                 "@vscode/markdown-it-katex": "^1.1.2",

--- a/browser/flagr-ui/package.json
+++ b/browser/flagr-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flagr-ui",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/docs/api_docs/bundle.yaml
+++ b/docs/api_docs/bundle.yaml
@@ -4,7 +4,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration
     microservice. The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.3
+  version: 1.2.4
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger/index.yaml
+++ b/swagger/index.yaml
@@ -5,7 +5,7 @@ info:
     Flagr is a feature flagging, A/B testing and dynamic configuration microservice.
     The base path for all the APIs is "/api/v1".
   title: Flagr
-  version: 1.2.3
+  version: 1.2.4
 tags:
   - name: flag
     description: Everything about the flag

--- a/swagger_gen/restapi/doc.go
+++ b/swagger_gen/restapi/doc.go
@@ -8,7 +8,7 @@
 //	  http
 //	Host: localhost
 //	BasePath: /api/v1
-//	Version: 1.2.3
+//	Version: 1.2.4
 //
 //	Consumes:
 //	  - application/json

--- a/swagger_gen/restapi/embedded_spec.go
+++ b/swagger_gen/restapi/embedded_spec.go
@@ -28,7 +28,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.3"
+    "version": "1.2.4"
   },
   "basePath": "/api/v1",
   "paths": {
@@ -2685,7 +2685,7 @@ func init() {
   "info": {
     "description": "Flagr is a feature flagging, A/B testing and dynamic configuration microservice. The base path for all the APIs is \"/api/v1\".\n",
     "title": "Flagr",
-    "version": "1.2.3"
+    "version": "1.2.4"
   },
   "basePath": "/api/v1",
   "paths": {


### PR DESCRIPTION
## Changes since 1.2.3

### Features
- feat: read-only UI for eval-only mode (`json_file`/`json_http`) (#764) — the UI now works on eval-only (GitOps) deployments as a read-only flag browser fed by `GET /export/eval_cache/json`, with the Debug Console available and all write APIs returning 403.

### Dependencies
- chore(deps): bump fast-uri from 3.1.4 to 3.1.5 in /browser/flagr-ui (#765)
- chore(deps): bump postcss from 8.5.19 to 8.5.26 in /docs (#766)
- chore(deps-dev): bump mermaid from 11.16.0 to 11.16.1 in /docs (#767)
- chore(deps-dev): bump dompurify from 3.4.12 to 3.4.13 in /docs (#768)

## Release checklist

- Version bumped to 1.2.4 in `swagger/index.yaml`, regenerated `docs/api_docs/bundle.yaml` + `swagger_gen/` (`make gen`), and `browser/flagr-ui/package.json` / `package-lock.json` — same file set as the 1.2.3 release prep (#763).
- `make test` green (lint, swagger validate, all Go tests); UI production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
